### PR TITLE
Graphql

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -36,6 +36,7 @@ gem 'jsonapi_spec_helpers', '~> 0.4.10', require: false
 gem 'jsonapi_suite', '~> 0.7'
 gem 'jsonapi_swagger_helpers', '~> 0.6', require: false
 gem 'kaminari', '~> 1.0'
+gem 'graphql'
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -69,6 +69,7 @@ GEM
     ffi (1.10.0)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
+    graphql (1.9.3)
     i18n (1.5.3)
       concurrent-ruby (~> 1.0)
     jaro_winkler (1.5.2)
@@ -251,6 +252,7 @@ DEPENDENCIES
   dotenv-rails
   factory_bot_rails (~> 4.0)
   faker (~> 1.7)
+  graphql
   jsonapi-rails (~> 0.3.1)
   jsonapi_spec_helpers (~> 0.4.10)
   jsonapi_suite (~> 0.7)

--- a/app/controllers/graphql_controller.rb
+++ b/app/controllers/graphql_controller.rb
@@ -1,4 +1,4 @@
-class GraphqlController < ApplicationController
+class GraphqlController < ActionController::API
   def execute
     variables = ensure_hash(params[:variables])
     query = params[:query]

--- a/app/controllers/graphql_controller.rb
+++ b/app/controllers/graphql_controller.rb
@@ -1,0 +1,43 @@
+class GraphqlController < ApplicationController
+  def execute
+    variables = ensure_hash(params[:variables])
+    query = params[:query]
+    operation_name = params[:operationName]
+    context = {
+      # Query context goes here, for example:
+      # current_user: current_user,
+    }
+    result = MusicboxApiSchema.execute(query, variables: variables, context: context, operation_name: operation_name)
+    render json: result
+  rescue => e
+    raise e unless Rails.env.development?
+    handle_error_in_development e
+  end
+
+  private
+
+  # Handle form data, JSON body, or a blank value
+  def ensure_hash(ambiguous_param)
+    case ambiguous_param
+    when String
+      if ambiguous_param.present?
+        ensure_hash(JSON.parse(ambiguous_param))
+      else
+        {}
+      end
+    when Hash, ActionController::Parameters
+      ambiguous_param
+    when nil
+      {}
+    else
+      raise ArgumentError, "Unexpected parameter: #{ambiguous_param}"
+    end
+  end
+
+  def handle_error_in_development(e)
+    logger.error e.message
+    logger.error e.backtrace.join("\n")
+
+    render json: { error: { message: e.message, backtrace: e.backtrace }, data: {} }, status: 500
+  end
+end

--- a/app/graphql/musicbox_api_schema.rb
+++ b/app/graphql/musicbox_api_schema.rb
@@ -1,0 +1,4 @@
+class MusicboxApiSchema < GraphQL::Schema
+  mutation(Types::MutationType)
+  query(Types::QueryType)
+end

--- a/app/graphql/mutations.rb
+++ b/app/graphql/mutations.rb
@@ -1,0 +1,2 @@
+module Mutations
+end

--- a/app/graphql/mutations/base_mutation.rb
+++ b/app/graphql/mutations/base_mutation.rb
@@ -1,0 +1,4 @@
+module Mutations
+  class BaseMutation < GraphQL::Schema::RelayClassicMutation
+  end
+end

--- a/app/graphql/mutations/create_room_queue.rb
+++ b/app/graphql/mutations/create_room_queue.rb
@@ -1,0 +1,35 @@
+module Mutations
+  class CreateRoomQueue < Mutations::BaseMutation
+    argument :order, String, required: true
+    argument :room_id, String, required: true
+    argument :song_id, String, required: true
+    argument :user_id, String, required: true
+
+    field :room_queue, Types::RoomQueueType, null: true
+    field :errors, [String], null: true
+
+    def resolve(order:, room_id:, song_id:, user_id:)
+      room_queue = RoomQueue.new(order: order, room_id: room_id, song_id: song_id, user_id: user_id)
+      if room_queue.save
+        ActionCable.server.broadcast('queue', enqueued_songs(room_queue).map(&:attributes))
+        ActionCable.server.broadcast('now_playing', enqueued_songs(room_queue).map(&:attributes))
+
+        {
+          room_queue: room_queue,
+          errors: [],
+        }
+      else
+        {
+          room_queue: nil,
+          errors: room_queue.errors.full_messages
+        }
+      end
+    end
+
+    private
+
+    def enqueued_songs(room_queue)
+      room_queue.room.enqueued_songs
+    end
+  end
+end

--- a/app/graphql/mutations/create_song.rb
+++ b/app/graphql/mutations/create_song.rb
@@ -1,0 +1,32 @@
+module Mutations
+  class CreateSong < Mutations::BaseMutation
+    argument :name, String, required: true
+    argument :youtube_id, String, required: true
+
+    field :song, Types::SongType, null: true
+    field :errors, [String], null: true
+
+    def resolve(name:, youtube_id:)
+      persisted_song = Song.find_by(youtube_id: youtube_id)
+      if persisted_song.present?
+        return {
+          song: persisted_song,
+          errors: []
+        }
+      end
+
+      song = Song.new(name: name, youtube_id: youtube_id)
+      if song.save
+        {
+          song: song,
+          errors: [],
+        }
+      else
+        {
+          song: nil,
+          errors: song.errors.full_messages
+        }
+      end
+    end
+  end
+end

--- a/app/graphql/types.rb
+++ b/app/graphql/types.rb
@@ -1,0 +1,2 @@
+module Types
+end

--- a/app/graphql/types/base_enum.rb
+++ b/app/graphql/types/base_enum.rb
@@ -1,0 +1,4 @@
+module Types
+  class BaseEnum < GraphQL::Schema::Enum
+  end
+end

--- a/app/graphql/types/base_input_object.rb
+++ b/app/graphql/types/base_input_object.rb
@@ -1,0 +1,4 @@
+module Types
+  class BaseInputObject < GraphQL::Schema::InputObject
+  end
+end

--- a/app/graphql/types/base_interface.rb
+++ b/app/graphql/types/base_interface.rb
@@ -1,0 +1,5 @@
+module Types
+  module BaseInterface
+    include GraphQL::Schema::Interface
+  end
+end

--- a/app/graphql/types/base_object.rb
+++ b/app/graphql/types/base_object.rb
@@ -1,0 +1,4 @@
+module Types
+  class BaseObject < GraphQL::Schema::Object
+  end
+end

--- a/app/graphql/types/base_scalar.rb
+++ b/app/graphql/types/base_scalar.rb
@@ -1,0 +1,4 @@
+module Types
+  class BaseScalar < GraphQL::Schema::Scalar
+  end
+end

--- a/app/graphql/types/base_union.rb
+++ b/app/graphql/types/base_union.rb
@@ -1,0 +1,4 @@
+module Types
+  class BaseUnion < GraphQL::Schema::Union
+  end
+end

--- a/app/graphql/types/mutation_type.rb
+++ b/app/graphql/types/mutation_type.rb
@@ -1,0 +1,10 @@
+module Types
+  class MutationType < Types::BaseObject
+    # TODO: remove me
+    field :test_field, String, null: false,
+      description: "An example field added by the generator"
+    def test_field
+      "Hello World"
+    end
+  end
+end

--- a/app/graphql/types/mutation_type.rb
+++ b/app/graphql/types/mutation_type.rb
@@ -1,10 +1,6 @@
 module Types
   class MutationType < Types::BaseObject
-    # TODO: remove me
-    field :test_field, String, null: false,
-      description: "An example field added by the generator"
-    def test_field
-      "Hello World"
-    end
+    field :create_room_queue, mutation: Mutations::CreateRoomQueue
+    field :create_song, mutation: Mutations::CreateSong
   end
 end

--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -1,0 +1,13 @@
+module Types
+  class QueryType < Types::BaseObject
+    # Add root-level fields here.
+    # They will be entry points for queries on your schema.
+
+    # TODO: remove me
+    field :test_field, String, null: false,
+      description: "An example field added by the generator"
+    def test_field
+      "Hello World!"
+    end
+  end
+end

--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -1,13 +1,19 @@
 module Types
   class QueryType < Types::BaseObject
-    # Add root-level fields here.
-    # They will be entry points for queries on your schema.
+    graphql_name "Query"
 
-    # TODO: remove me
-    field :test_field, String, null: false,
-      description: "An example field added by the generator"
-    def test_field
-      "Hello World!"
+    field :songs, [Types::SongType], null: true do
+    end
+
+    field :room_queues, [Types::RoomQueueType], null: true do
+    end
+
+    def room_queues
+      RoomQueue.all
+    end
+
+    def songs
+      Song.all
     end
   end
 end

--- a/app/graphql/types/room_queue_type.rb
+++ b/app/graphql/types/room_queue_type.rb
@@ -1,0 +1,11 @@
+module Types
+  class RoomQueueType < Types::BaseObject
+    graphql_name 'RoomQueue'
+
+    field :id, ID, null: false
+    field :order, Int, null: false
+    field :room, Types::RoomType, null: false
+    field :song, Types::SongType, null: false
+    field :user, Types::UserType, null: false
+  end
+end

--- a/app/graphql/types/room_type.rb
+++ b/app/graphql/types/room_type.rb
@@ -1,0 +1,8 @@
+module Types
+  class RoomType < Types::BaseObject
+    graphql_name 'Room'
+
+    field :id, ID, null: false
+    field :name, String, null: false
+  end
+end

--- a/app/graphql/types/song_type.rb
+++ b/app/graphql/types/song_type.rb
@@ -1,0 +1,10 @@
+module Types
+  class SongType < Types::BaseObject
+    graphql_name 'Song'
+
+    field :id, ID, null: false
+    field :duration_in_seconds, Int, null: true
+    field :name, String, null: false
+    field :youtube_id, String, null: false
+  end
+end

--- a/app/graphql/types/user_type.rb
+++ b/app/graphql/types/user_type.rb
@@ -1,0 +1,9 @@
+module Types
+  class UserType < Types::BaseObject
+    graphql_name 'User'
+
+    field :id, ID, null: false
+    field :name, String, null: false
+    field :email, String, null: false
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,6 @@
 Rails.application.routes.draw do
 
+  post "/graphql", to: "graphql#execute"
   mount ActionCable.server => '/cable'
 
   scope path: '/api' do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,12 +1,13 @@
 Rails.application.routes.draw do
 
-  post "/graphql", to: "graphql#execute"
   mount ActionCable.server => '/cable'
 
   scope path: '/api' do
     resources :docs, only: [:index], path: '/swagger'
 
     scope path: '/v1' do
+      post "/graphql", to: "graphql#execute"
+
       resources :users
       resources :rooms, only: [:show]
       resources :room_queues, only: [:create]

--- a/spec/graphql/room_queues_spec.rb
+++ b/spec/graphql/room_queues_spec.rb
@@ -1,0 +1,88 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Songs", type: :request do
+  include JsonHelper
+
+  def query(order:, room_id:, song_id:, user_id:)
+    %(
+      mutation {
+        createRoomQueue(input:{
+          order: "#{order}",
+          roomId: "#{room_id}"
+          songId: "#{song_id}"
+          userId: "#{user_id}"
+        }) {
+          roomQueue {
+            id
+            order
+            room {
+              id
+            }
+            song {
+              id
+            }
+            user {
+              id
+            }
+          }
+          errors
+        }
+      }
+    )
+  end
+
+  describe "#create" do
+    let(:room) { create(:room) }
+    let(:song) { create(:song) }
+    let(:user) { create(:user) }
+    it "can be created with a room, song, and user" do
+      q = query(order: 1, room_id: room.id, song_id: song.id, user_id: user.id)
+      post('/api/v1/graphql', params: { query: q })
+      data = json_body.dig(:data, :createRoomQueue)
+
+      id = data.dig(:roomQueue, :id)
+      rq = RoomQueue.find(id)
+      expect(rq.room).to eq(room)
+      expect(rq.song).to eq(song)
+      expect(rq.user).to eq(user)
+    end
+
+    it "broadcasts enqueued songs" do
+      expect do
+        q = query(order: 1, room_id: room.id, song_id: song.id, user_id: user.id)
+        post('/api/v1/graphql', params: { query: q })
+      end.to have_broadcasted_to("queue").and(have_broadcasted_to("now_playing"))
+    end
+
+    context "when missing required attributes" do
+      it "fails to persist when room is not specified" do
+        q = query(order: 1, room_id: SecureRandom.uuid, song_id: song.id, user_id: user.id)
+        post('/api/v1/graphql', params: { query: q })
+        data = json_body.dig(:data, :createRoomQueue)
+
+        expect(data[:roomQueue]).to be_nil
+        expect(data[:errors]).to match_array([include("Room must exist")])
+      end
+
+      it "fails to persist when song is not specified" do
+        q = query(order: 1, room_id: room.id, song_id: SecureRandom.uuid, user_id: user.id)
+        post('/api/v1/graphql', params: { query: q })
+        data = json_body.dig(:data, :createRoomQueue)
+
+        expect(data[:roomQueue]).to be_nil
+        expect(data[:errors]).to match_array([include("Song must exist")])
+      end
+
+      it "fails to persist when user is not specified" do
+        q = query(order: 1, room_id: room.id, song_id: song.id, user_id: SecureRandom.uuid)
+        post('/api/v1/graphql', params: { query: q })
+        data = json_body.dig(:data, :createRoomQueue)
+
+        expect(data[:roomQueue]).to be_nil
+        expect(data[:errors]).to match_array([include("User must exist")])
+      end
+    end
+  end
+end

--- a/spec/graphql/songs_spec.rb
+++ b/spec/graphql/songs_spec.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Songs", type: :request do
+  include JsonHelper
+
+  def query(name:, youtube_id:)
+    %(
+      mutation {
+        createSong(input:{
+          name: "#{name}",
+          youtubeId: "#{youtube_id}"
+        }) {
+          song {
+            id
+            name
+            youtubeId
+          }
+          errors
+        }
+      }
+    )
+  end
+
+  describe "#create" do
+    it "can be created" do
+      post('/api/v1/graphql', params: { query: query(name: "the name", youtube_id: "an-id") })
+      data = json_body.dig(:data, :createSong)
+      id = data.dig(:song, :id)
+
+      expect(Song.exists?(id)).to eq(true)
+      expect(data[:errors]).to be_blank
+    end
+
+    it "allows find-or-create by youtube_id" do
+      song = create(:song, youtube_id: "the-youtube-id")
+
+      expect do
+        post('/api/v1/graphql', params: { query: query(name: "the name", youtube_id: "the-youtube-id") })
+        data = json_body.dig(:data, :createSong)
+        id = data.dig(:song, :id)
+
+        expect(song.id).to eq(id)
+        expect(data[:errors]).to be_blank
+      end.to_not change(Song, :count)
+    end
+  end
+
+  context "when missing required attributes" do
+    it "fails to persist when youtube_id is not specified" do
+      expect do
+        post('/api/v1/graphql', params: { query: query(name: "the name", youtube_id: nil) })
+        data = json_body.dig(:data, :createSong)
+
+        expect(data[:song]).to be_nil
+        expect(data[:errors]).to match_array([include("Youtube can't be blank")])
+      end.to_not change(Song, :count)
+    end
+  end
+end


### PR DESCRIPTION
@sisk @DLavin23 

You all tired of digging around the awful jsonapi suite documentation?  I sure am.

This PR adds GraphQL and replicates the api functionality that has been tested through the request specs (new specs in `spec/graphql`).  There's even a graphql integration for websockets via [subscriptions](https://graphql-ruby.org/guides#subscriptions-guides), but I haven't done that yet.

Look at all of those [guides](https://graphql-ruby.org/guides).  Woah.  Look at that nice [graphql tooling](https://github.com/skevy/graphiql-app).