### PR TITLE
Better orderings

### DIFF
--- a/app/controllers/graphql_controller.rb
+++ b/app/controllers/graphql_controller.rb
@@ -6,6 +6,7 @@ class GraphqlController < ApplicationController
     context = {
       current_user: current_user
     }
+
     result = MusicboxApiSchema.execute(query, variables: variables, context: context, operation_name: operation_name)
     render json: result
   rescue => e

--- a/app/graphql/mutations/order_room_songs.rb
+++ b/app/graphql/mutations/order_room_songs.rb
@@ -15,8 +15,9 @@ module Mutations
                     )
         room_song.order = index + 1
         room_song.save!
-        BroadcastQueueWorker.perform_async(room_id)
       end
+
+      BroadcastQueueWorker.perform_async(room_id)
       {
         errors: []
       }

--- a/app/graphql/mutations/order_room_songs.rb
+++ b/app/graphql/mutations/order_room_songs.rb
@@ -1,13 +1,18 @@
 module Mutations
   class OrderRoomSongs < Mutations::BaseMutation
     argument :room_id, ID, required: true
-    argument :song_ids, [ID], required: true
+    argument :ordered_songs, [Types::OrderedSongObject], required: true
 
     field :errors, [String], null: true
 
-    def resolve(room_id:, song_ids:)
-      song_ids.each_with_index do |song_id, index|
-        room_song = RoomSong.find_or_initialize_by(song_id: song_id, user: context[:current_user], room_id: room_id)
+    def resolve(room_id:, ordered_songs:)
+      ordered_songs.each_with_index do |ordered_song, index|
+        room_song = RoomSong.find_or_initialize_by(
+                      id: ordered_song[:room_song_id],
+                      room_id: room_id,
+                      song_id: ordered_song[:song_id],
+                      user: context[:current_user]
+                    )
         room_song.order = index + 1
         room_song.save!
         BroadcastQueueWorker.perform_async(room_id)

--- a/app/graphql/types/enqueue_type.rb
+++ b/app/graphql/types/enqueue_type.rb
@@ -2,7 +2,7 @@ module Types
   class EnqueueType < Types::BaseObject
     graphql_name 'Enqueue'
 
-    field :order, Int, null: false
+    field :id, ID, null: false
     field :song, Types::SongType, null: false
     field :user, Types::UserType, null: false
     field :room, Types::RoomType, null: false

--- a/app/graphql/types/ordered_song_object.rb
+++ b/app/graphql/types/ordered_song_object.rb
@@ -1,0 +1,6 @@
+module Types
+  class OrderedSongObject < Types::BaseInputObject
+    argument :room_song_id, ID, required: true
+    argument :song_id, ID, required: true
+  end
+end

--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -22,7 +22,7 @@ module Types
       argument :for_user, Boolean, required: false
     end
 
-    def room_songs(room_id:, for_user:)
+    def room_songs(room_id:, for_user: false)
       # TODO:  Service class to determine real order
       songs = RoomSong.where(room_id: room_id)
       songs = songs.where(user: context[:current_user]) if for_user


### PR DESCRIPTION
@sisk @DLavin23 

Updates the `OrderRoomSongs` mutation to accept an array of objects of RoomSong id and Song id (allows for duplicate songs to be enqueued and reordered).  Uses the [input object](https://graphql-ruby.org/type_definitions/input_objects.html) pattern from graphql.

Supports [this react pr](https://github.com/tshuck/musicbox-react/pull/22).