### PR TITLE
Teams

### DIFF
--- a/app/graphql/mutations/join_room.rb
+++ b/app/graphql/mutations/join_room.rb
@@ -16,7 +16,7 @@ module Mutations
         }
       end
 
-      context[:current_user].update!(room_id: room_id)
+      context[:current_user].update!(active_room_id: room_id)
       BroadcastUsersWorker.perform_async(room.id)
 
       {

--- a/app/graphql/mutations/join_room.rb
+++ b/app/graphql/mutations/join_room.rb
@@ -8,7 +8,7 @@ module Mutations
     field :errors, [String], null: true
 
     def resolve(room_id:)
-      room = Room.find_by(id: room_id)
+      room = Room.find_by(id: room_id, team: context[:current_user].teams)
       if room.blank?
         return {
           room: nil,

--- a/app/graphql/mutations/order_room_playlist_records.rb
+++ b/app/graphql/mutations/order_room_playlist_records.rb
@@ -7,15 +7,16 @@ module Mutations
     field :errors, [String], null: true
 
     def resolve(ordered_records:)
-      room = Room.find(room_id)
+      room = Room.find(context[:current_user].active_room_id)
+
       ensure_user_in_rotation!(room)
 
       @errors = []
 
-      records = initialize_records!(room_id, ordered_records)
+      records = initialize_records!(room.id, ordered_records)
       records.each_with_index { |r, i| r.update!(order: i) }
 
-      BroadcastPlaylistWorker.perform_async(room_id)
+      BroadcastPlaylistWorker.perform_async(room.id)
       {
         errors: @errors
       }

--- a/app/graphql/mutations/order_room_playlist_records.rb
+++ b/app/graphql/mutations/order_room_playlist_records.rb
@@ -2,12 +2,11 @@
 
 module Mutations
   class OrderRoomPlaylistRecords < Mutations::BaseMutation
-    argument :room_id, ID, required: true
     argument :ordered_records, [Types::OrderedRoomPlaylistRecord], required: true
 
     field :errors, [String], null: true
 
-    def resolve(room_id:, ordered_records:)
+    def resolve(ordered_records:)
       room = Room.find(room_id)
       ensure_user_in_rotation!(room)
 

--- a/app/models/room.rb
+++ b/app/models/room.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Room < ApplicationRecord
-  has_many :users
+  has_many :users, foreign_key: :active_room_id
   has_many :room_playlist_records
   has_many :songs, through: :room_playlist_records
   belongs_to :current_record, foreign_key: :current_record_id, class_name: 'RoomPlaylistRecord', optional: true

--- a/app/models/room.rb
+++ b/app/models/room.rb
@@ -6,4 +6,5 @@ class Room < ApplicationRecord
   has_many :songs, through: :room_playlist_records
   belongs_to :current_record, foreign_key: :current_record_id, class_name: 'RoomPlaylistRecord', optional: true
   has_one :current_song, through: :current_record, source: :song
+  belongs_to :team
 end

--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -2,4 +2,6 @@
 
 class Team < ApplicationRecord
   belongs_to :owner, foreign_key: :owner_id, class_name: 'User'
+  has_many :team_users
+  has_many :users, through: :team_users
 end

--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+class Team < ApplicationRecord
+  belongs_to :owner, foreign_key: :owner_id, class_name: 'User'
+end

--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -3,5 +3,6 @@
 class Team < ApplicationRecord
   belongs_to :owner, foreign_key: :owner_id, class_name: 'User'
   has_many :team_users
+  has_many :rooms
   has_many :users, through: :team_users
 end

--- a/app/models/team_user.rb
+++ b/app/models/team_user.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class TeamUser < ApplicationRecord
+  self.table_name = 'teams_users'
+  belongs_to :user
+  belongs_to :team
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -6,7 +6,7 @@ class User < ApplicationRecord
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
 
-  belongs_to :room, optional: true
+  belongs_to :room, optional: true, foreign_key: :active_room_id
   has_many :user_library_records
   has_many :songs, through: :user_library_records
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -6,8 +6,8 @@ class User < ApplicationRecord
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
 
-  belongs_to :room, optional: true, foreign_key: :active_room_id
-  belongs_to :team, optional: true, foreign_key: :active_team_id
+  belongs_to :active_room, optional: true, foreign_key: :active_room_id, class_name: 'Room'
+  belongs_to :active_team, optional: true, foreign_key: :active_team_id, class_name: 'Team'
 
   has_many :user_library_records
   has_many :songs, through: :user_library_records

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -9,4 +9,6 @@ class User < ApplicationRecord
   belongs_to :room, optional: true, foreign_key: :active_room_id
   has_many :user_library_records
   has_many :songs, through: :user_library_records
+  has_many :team_users
+  has_many :teams, through: :team_users
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -7,6 +7,8 @@ class User < ApplicationRecord
          :recoverable, :rememberable, :validatable
 
   belongs_to :room, optional: true, foreign_key: :active_room_id
+  belongs_to :team, optional: true, foreign_key: :active_team_id
+
   has_many :user_library_records
   has_many :songs, through: :user_library_records
   has_many :team_users

--- a/db/migrate/20191231013211_update_room_for_user.rb
+++ b/db/migrate/20191231013211_update_room_for_user.rb
@@ -1,0 +1,5 @@
+class UpdateRoomForUser < ActiveRecord::Migration[6.0]
+  def change
+    rename_column :users, :room_id, :active_room_id
+  end
+end

--- a/db/migrate/20191231014000_create_teams.rb
+++ b/db/migrate/20191231014000_create_teams.rb
@@ -1,0 +1,10 @@
+class CreateTeams < ActiveRecord::Migration[6.0]
+  def change
+    create_table :teams, id: :uuid do |t|
+      t.string :name
+      t.uuid :owner_id
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20191231014524_add_team_to_room.rb
+++ b/db/migrate/20191231014524_add_team_to_room.rb
@@ -1,0 +1,5 @@
+class AddTeamToRoom < ActiveRecord::Migration[6.0]
+  def change
+    add_column :rooms, :team_id, :uuid
+  end
+end

--- a/db/migrate/20191231015122_create_teams_users.rb
+++ b/db/migrate/20191231015122_create_teams_users.rb
@@ -1,0 +1,12 @@
+class CreateTeamsUsers < ActiveRecord::Migration[6.0]
+  def change
+    create_table :teams_users, id: :uuid do |t|
+      t.uuid :team_id
+      t.uuid :user_id
+
+      t.index :team_id
+      t.index :user_id
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20191231020447_add_active_team_to_users.rb
+++ b/db/migrate/20191231020447_add_active_team_to_users.rb
@@ -1,0 +1,5 @@
+class AddActiveTeamToUsers < ActiveRecord::Migration[6.0]
+  def change
+    add_column :users, :active_team_id, :uuid
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -12,7 +12,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20_190_929_003_240) do
+ActiveRecord::Schema.define(version: 20_191_231_013_211) do
   # These are extensions that must be enabled in order to support this database
   enable_extension 'pgcrypto'
   enable_extension 'plpgsql'
@@ -107,10 +107,10 @@ ActiveRecord::Schema.define(version: 20_190_929_003_240) do
     t.datetime 'created_at', null: false
     t.datetime 'updated_at', null: false
     t.string 'name'
-    t.uuid 'room_id'
+    t.uuid 'active_room_id'
+    t.index ['active_room_id'], name: 'index_users_on_active_room_id'
     t.index ['email'], name: 'index_users_on_email', unique: true
     t.index ['reset_password_token'], name: 'index_users_on_reset_password_token', unique: true
-    t.index ['room_id'], name: 'index_users_on_room_id'
   end
 
   add_foreign_key 'oauth_access_grants', 'oauth_applications', column: 'application_id'

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -12,7 +12,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20_191_231_013_211) do
+ActiveRecord::Schema.define(version: 20_191_231_014_000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension 'pgcrypto'
   enable_extension 'plpgsql'
@@ -87,6 +87,13 @@ ActiveRecord::Schema.define(version: 20_191_231_013_211) do
     t.string 'youtube_id'
     t.string 'description'
     t.index ['youtube_id'], name: 'index_songs_on_youtube_id'
+  end
+
+  create_table 'teams', id: :uuid, default: -> { 'gen_random_uuid()' }, force: :cascade do |t|
+    t.string 'name'
+    t.uuid 'owner_id'
+    t.datetime 'created_at', precision: 6, null: false
+    t.datetime 'updated_at', precision: 6, null: false
   end
 
   create_table 'user_library_records', id: :uuid, default: -> { 'gen_random_uuid()' }, force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -12,7 +12,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20_191_231_014_000) do
+ActiveRecord::Schema.define(version: 20_191_231_014_524) do
   # These are extensions that must be enabled in order to support this database
   enable_extension 'pgcrypto'
   enable_extension 'plpgsql'
@@ -77,6 +77,7 @@ ActiveRecord::Schema.define(version: 20_191_231_014_000) do
     t.datetime 'updated_at', null: false
     t.uuid 'current_record_id'
     t.uuid 'user_rotation', default: [], array: true
+    t.uuid 'team_id'
   end
 
   create_table 'songs', id: :uuid, default: -> { 'gen_random_uuid()' }, force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -12,7 +12,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20_191_231_014_524) do
+ActiveRecord::Schema.define(version: 20_191_231_015_122) do
   # These are extensions that must be enabled in order to support this database
   enable_extension 'pgcrypto'
   enable_extension 'plpgsql'
@@ -95,6 +95,15 @@ ActiveRecord::Schema.define(version: 20_191_231_014_524) do
     t.uuid 'owner_id'
     t.datetime 'created_at', precision: 6, null: false
     t.datetime 'updated_at', precision: 6, null: false
+  end
+
+  create_table 'teams_users', id: :uuid, default: -> { 'gen_random_uuid()' }, force: :cascade do |t|
+    t.uuid 'team_id'
+    t.uuid 'user_id'
+    t.datetime 'created_at', precision: 6, null: false
+    t.datetime 'updated_at', precision: 6, null: false
+    t.index ['team_id'], name: 'index_teams_users_on_team_id'
+    t.index ['user_id'], name: 'index_teams_users_on_user_id'
   end
 
   create_table 'user_library_records', id: :uuid, default: -> { 'gen_random_uuid()' }, force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -12,7 +12,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20_191_231_015_122) do
+ActiveRecord::Schema.define(version: 20_191_231_020_447) do
   # These are extensions that must be enabled in order to support this database
   enable_extension 'pgcrypto'
   enable_extension 'plpgsql'
@@ -125,6 +125,7 @@ ActiveRecord::Schema.define(version: 20_191_231_015_122) do
     t.datetime 'updated_at', null: false
     t.string 'name'
     t.uuid 'active_room_id'
+    t.uuid 'active_team_id'
     t.index ['active_room_id'], name: 'index_users_on_active_room_id'
     t.index ['email'], name: 'index_users_on_email', unique: true
     t.index ['reset_password_token'], name: 'index_users_on_reset_password_token', unique: true

--- a/spec/factories/room.rb
+++ b/spec/factories/room.rb
@@ -4,5 +4,6 @@ FactoryBot.define do
   factory :room do
     name { 'Banjo Town' }
     current_record { nil }
+    team
   end
 end

--- a/spec/factories/team.rb
+++ b/spec/factories/team.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :team do
+    name { 'Fine Musical Folks' }
+    owner { create(:user) }
+  end
+end

--- a/spec/integration/requests_spec.rb
+++ b/spec/integration/requests_spec.rb
@@ -8,10 +8,11 @@ RSpec.describe 'Requests Integration', type: :request do
   include GraphQLHelper
   include JsonHelper
 
-  let!(:room) { create(:room) }
-  let!(:truman) { create(:user, name: 'truman') }
-  let!(:dan) { create(:user, name: 'dan') }
-  let!(:sean) { create(:user, name: 'sean') }
+  let!(:team) { create(:team) }
+  let!(:room) { create(:room, team: team) }
+  let!(:truman) { create(:user, name: 'truman', teams: [team]) }
+  let!(:dan) { create(:user, name: 'dan', teams: [team]) }
+  let!(:sean) { create(:user, name: 'sean', teams: [team]) }
 
   it 'Allows three users to share a meaningful experience together' do
     Sidekiq::Testing.inline! do

--- a/spec/integration/requests_spec.rb
+++ b/spec/integration/requests_spec.rb
@@ -102,7 +102,7 @@ RSpec.describe 'Requests Integration', type: :request do
 
         authed_post(
           url: '/api/v1/graphql',
-          body: { query: order_room_playlist_records_mutation(room_id: room.id, records: records) },
+          body: { query: order_room_playlist_records_mutation(records: records) },
           user: dan
         )
       end.to(broadcast_to(QueuesChannel.broadcasting_for(room)).with do |data|
@@ -127,7 +127,7 @@ RSpec.describe 'Requests Integration', type: :request do
 
         authed_post(
           url: '/api/v1/graphql',
-          body: { query: order_room_playlist_records_mutation(room_id: room.id, records: records) },
+          body: { query: order_room_playlist_records_mutation(records: records) },
           user: dan
         )
       end.to(broadcast_to(QueuesChannel.broadcasting_for(room)).with do |data|
@@ -150,7 +150,7 @@ RSpec.describe 'Requests Integration', type: :request do
 
         authed_post(
           url: '/api/v1/graphql',
-          body: { query: order_room_playlist_records_mutation(room_id: room.id, records: records) },
+          body: { query: order_room_playlist_records_mutation(records: records) },
           user: truman
         )
       end.to(broadcast_to(QueuesChannel.broadcasting_for(room)).with do |data|
@@ -178,7 +178,7 @@ RSpec.describe 'Requests Integration', type: :request do
 
         authed_post(
           url: '/api/v1/graphql',
-          body: { query: order_room_playlist_records_mutation(room_id: room.id, records: records) },
+          body: { query: order_room_playlist_records_mutation(records: records) },
           user: sean
         )
       end.to(broadcast_to(QueuesChannel.broadcasting_for(room)).with do |data|
@@ -209,7 +209,7 @@ RSpec.describe 'Requests Integration', type: :request do
 
         authed_post(
           url: '/api/v1/graphql',
-          body: { query: order_room_playlist_records_mutation(room_id: room.id, records: records) },
+          body: { query: order_room_playlist_records_mutation(records: records) },
           user: sean
         )
       end.to(broadcast_to(QueuesChannel.broadcasting_for(room)).with do |data|
@@ -239,7 +239,7 @@ RSpec.describe 'Requests Integration', type: :request do
 
         authed_post(
           url: '/api/v1/graphql',
-          body: { query: order_room_playlist_records_mutation(room_id: room.id, records: records) },
+          body: { query: order_room_playlist_records_mutation(records: records) },
           user: truman
         )
       end.to(broadcast_to(QueuesChannel.broadcasting_for(room)).with do |data|

--- a/spec/models/room_spec.rb
+++ b/spec/models/room_spec.rb
@@ -25,8 +25,8 @@ RSpec.describe Room, type: :model do
     end
 
     it 'has many users' do
-      user1 = create(:user, room: room)
-      user2 = create(:user, room: room)
+      user1 = create(:user, active_room: room)
+      user2 = create(:user, active_room: room)
 
       expect(room.reload.users).to match_array([user1, user2])
     end

--- a/spec/models/room_spec.rb
+++ b/spec/models/room_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe Room, type: :model do
-  let(:room) { described_class.create! }
+  let(:room) { described_class.create!(team: create(:team)) }
 
   describe 'relationships' do
     it 'has many playlist records' do

--- a/spec/models/team_spec.rb
+++ b/spec/models/team_spec.rb
@@ -21,5 +21,13 @@ RSpec.describe Team, type: :model do
 
       expect(team.reload.users).to match_array([user1, user2])
     end
+
+    it 'may have many rooms' do
+      team = described_class.create!(owner: owner)
+      room1 = create(:room, team: team)
+      room2 = create(:room, team: team)
+
+      expect(team.reload.rooms).to match_array([room1, room2])
+    end
   end
 end

--- a/spec/models/team_spec.rb
+++ b/spec/models/team_spec.rb
@@ -4,10 +4,22 @@ require 'rails_helper'
 
 RSpec.describe Team, type: :model do
   describe 'relationships' do
+    let(:owner) { create(:user) }
+
     it 'belongs to an owner' do
-      owner = create(:user)
       team = described_class.create!(owner: owner)
       expect(team.owner).to eq(owner)
+    end
+
+    it 'may have many users' do
+      user1 = create(:user)
+      user2 = create(:user)
+
+      team = described_class.create!(owner: owner)
+      team.users << user1
+      team.users << user2
+
+      expect(team.reload.users).to match_array([user1, user2])
     end
   end
 end

--- a/spec/models/team_spec.rb
+++ b/spec/models/team_spec.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Team, type: :model do
+  describe 'relationships' do
+    it 'belongs to an owner' do
+      owner = create(:user)
+      team = described_class.create!(owner: owner)
+      expect(team.owner).to eq(owner)
+    end
+  end
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -27,16 +27,16 @@ RSpec.describe User, type: :model do
 
     it 'may belong to one active room' do
       room = create(:room)
-      user.update!(room: room)
+      user.update!(active_room: room)
 
-      expect(user.room).to eq(room)
+      expect(user.active_room).to eq(room)
     end
 
     it 'may belong to one active team' do
       team = create(:team)
-      user.update!(team: team)
+      user.update!(active_team: team)
 
-      expect(user.team).to eq(team)
+      expect(user.active_team).to eq(team)
     end
 
     it 'may be part of many teams' do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -31,5 +31,15 @@ RSpec.describe User, type: :model do
 
       expect(user.room).to eq(room)
     end
+
+    it 'may be part of many teams' do
+      team1 = create(:team)
+      team2 = create(:team)
+
+      user.teams << team1
+      user.teams << team2
+
+      expect(user.reload.teams).to match_array([team1, team2])
+    end
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -25,11 +25,18 @@ RSpec.describe User, type: :model do
       expect(user.reload.songs).to match_array([song1, song2, song2])
     end
 
-    it 'may belong to a room' do
+    it 'may belong to one active room' do
       room = create(:room)
       user.update!(room: room)
 
       expect(user.room).to eq(room)
+    end
+
+    it 'may belong to one active team' do
+      team = create(:team)
+      user.update!(team: team)
+
+      expect(user.team).to eq(team)
     end
 
     it 'may be part of many teams' do

--- a/spec/mutations/join_room_spec.rb
+++ b/spec/mutations/join_room_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-RSpec.describe 'Create Song', type: :request do
+RSpec.describe 'Join Room', type: :request do
   include AuthHelper
   include GraphQLHelper
   include JsonHelper
@@ -22,7 +22,7 @@ RSpec.describe 'Create Song', type: :request do
 
       expect(data.dig(:room, :id)).to eq(room.id)
       expect(data[:errors]).to be_empty
-      expect(current_user.reload.room).to eq(room)
+      expect(current_user.reload.active_room).to eq(room)
     end
 
     it 'enqueues a broadcast room worker' do
@@ -39,7 +39,7 @@ RSpec.describe 'Create Song', type: :request do
 
   describe 'error' do
     it 'does not allow a user to join a nonexistant room' do
-      current_user.update!(room: nil)
+      current_user.update!(active_room: nil)
       authed_post(
         url: '/api/v1/graphql',
         body: { query: join_room_mutation(room_id: SecureRandom.uuid) },
@@ -48,7 +48,7 @@ RSpec.describe 'Create Song', type: :request do
       data = json_body.dig(:data, :joinRoom)
 
       expect(data[:errors]).not_to be_empty
-      expect(current_user.reload.room).to be_nil
+      expect(current_user.reload.active_room).to be_nil
     end
   end
 end

--- a/spec/mutations/order_room_playlist_records_spec.rb
+++ b/spec/mutations/order_room_playlist_records_spec.rb
@@ -7,8 +7,8 @@ RSpec.describe 'Create Song', type: :request do
   include GraphQLHelper
   include JsonHelper
 
-  let(:current_user) { create(:user) }
   let(:room) { create(:room) }
+  let(:current_user) { create(:user, active_room_id: room.id) }
 
   describe 'song ordering' do
     it 'reorders existing songs' do
@@ -21,7 +21,7 @@ RSpec.describe 'Create Song', type: :request do
       ]
       authed_post(
         url: '/api/v1/graphql',
-        body: { query: order_room_playlist_records_mutation(room_id: room.id, records: records) },
+        body: { query: order_room_playlist_records_mutation(records: records) },
         user: current_user
       )
 
@@ -41,7 +41,7 @@ RSpec.describe 'Create Song', type: :request do
       ]
       authed_post(
         url: '/api/v1/graphql',
-        body: { query: order_room_playlist_records_mutation(room_id: room.id, records: records) },
+        body: { query: order_room_playlist_records_mutation(records: records) },
         user: current_user
       )
 
@@ -62,7 +62,7 @@ RSpec.describe 'Create Song', type: :request do
       records = [{ song_id: song.id }]
       authed_post(
         url: '/api/v1/graphql',
-        body: { query: order_room_playlist_records_mutation(room_id: room.id, records: records) },
+        body: { query: order_room_playlist_records_mutation(records: records) },
         user: current_user
       )
 
@@ -79,7 +79,7 @@ RSpec.describe 'Create Song', type: :request do
       records = [{ song_id: song.id }]
       authed_post(
         url: '/api/v1/graphql',
-        body: { query: order_room_playlist_records_mutation(room_id: room.id, records: records) },
+        body: { query: order_room_playlist_records_mutation(records: records) },
         user: current_user
       )
 
@@ -96,7 +96,7 @@ RSpec.describe 'Create Song', type: :request do
       records = [{ song_id: song.id }]
       authed_post(
         url: '/api/v1/graphql',
-        body: { query: order_room_playlist_records_mutation(room_id: room.id, records: records) },
+        body: { query: order_room_playlist_records_mutation(records: records) },
         user: current_user
       )
 
@@ -122,7 +122,7 @@ RSpec.describe 'Create Song', type: :request do
       ]
       authed_post(
         url: '/api/v1/graphql',
-        body: { query: order_room_playlist_records_mutation(room_id: room.id, records: records) },
+        body: { query: order_room_playlist_records_mutation(records: records) },
         user: current_user
       )
 

--- a/spec/support/graphql_helper.rb
+++ b/spec/support/graphql_helper.rb
@@ -16,7 +16,7 @@ module GraphQLHelper
     )
   end
 
-  def order_room_playlist_records_mutation(room_id:, records:) # rubocop:disable Metrics/MethodLength
+  def order_room_playlist_records_mutation(records:)
     input = records.map do |record|
       str = '{ '
       str += "songId: \"#{record[:song_id]}\""
@@ -27,7 +27,6 @@ module GraphQLHelper
     %(
       mutation {
         orderRoomPlaylistRecords(input:{
-          roomId: "#{room_id}",
           orderedRecords: [#{input.join(',')}]
         }) {
           errors

--- a/spec/workers/broadcast_users_worker_spec.rb
+++ b/spec/workers/broadcast_users_worker_spec.rb
@@ -8,8 +8,8 @@ RSpec.describe BroadcastUsersWorker, type: :worker do
 
   describe '#perform' do
     it 'broadcasts a list of users in the room' do
-      user1 = create(:user, room: room)
-      user2 = create(:user, room: room)
+      user1 = create(:user, active_room: room)
+      user2 = create(:user, active_room: room)
 
       expect do
         worker.perform(room.id)


### PR DESCRIPTION
@DLavin23 

This PR:
  - Clarifies a user's active room association
  - Removes explicit `room_id` from song ordering mutation in favor of relying on user's active room
  - Introduces teams:
    - A room must belong to a team, a team may have many rooms
    - A user may belong to many teams, but has one `active_team`
    - Restricts which rooms a user may join to only those that share a team with them