### PR TITLE
Allow message to be sent when user leaves a room

### DIFF
--- a/app/channels/users_channel.rb
+++ b/app/channels/users_channel.rb
@@ -2,13 +2,8 @@
 
 class UsersChannel < ApplicationCable::Channel
   def subscribed
-    room = Room.find(params[:room_id])
-    stream_for room
-  end
+    return reject if current_user.active_room.blank?
 
-  def unsubscribed
-    room_id = current_user.room_id
-    current_user.update!(room: nil)
-    BroadcastUsersWorker.perform_async(room_id)
+    stream_for current_user.active_room
   end
 end

--- a/app/graphql/mutations/room_activate.rb
+++ b/app/graphql/mutations/room_activate.rb
@@ -16,8 +16,11 @@ module Mutations
         }
       end
 
-      context[:current_user].update!(active_room_id: room_id)
-      BroadcastUsersWorker.perform_async(room.id)
+      previous_room_id = current_user.active_room_id
+      current_user.update!(active_room_id: room_id)
+
+      BroadcastUsersWorker.perform_async(previous_room_id) if previous_room_id.present?
+      BroadcastUsersWorker.perform_async(room_id)
 
       {
         room: room,


### PR DESCRIPTION
Removes unsubscribe logic, allows a message to be broadcast when a user switches rooms.