### PR TITLE
My beautiful library

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Note that setting up the services with `bin/setup` will create the appropriate d
 
 - [http://localhost:3000/graphiql](http://localhost:3000/graphiql)
   - The GraphQL graphical query interface.  Allows you to perform arbitrary queries and see results.
+  - **NOTE:** Many queries/mutations execute within the context of the current authenticated user.  The [graphiql initialize](config/initializers/graphiql.rb) assumes that the seed script has been run and will attempt to use the user identified by the email **a@a.a**.  If this user does not exist, you'll probably get a bunch of errors on the graphiql page.
 - [http://localhost:3000/workers](http://localhost:3000/workers)
   - The Sidekiq dashboard where you can see your background workers while away the hours while waiting on work to do.
 

--- a/app/workers/broadcast_users_worker.rb
+++ b/app/workers/broadcast_users_worker.rb
@@ -15,7 +15,11 @@ class BroadcastUsersWorker
     %(
       query($id: ID!) {
         room(id: $id) {
-          users { id, email }
+          users {
+            id
+            name
+            email
+          }
         }
       }
     )

--- a/config/initializers/graphiql.rb
+++ b/config/initializers/graphiql.rb
@@ -3,6 +3,7 @@
 def graphiql_doorkeeper_token
   user = User.find_by(email: 'a@a.a')
   return if user.blank?
+
   token = Doorkeeper::AccessToken.create!(resource_owner_id: user.id, expires_in: nil)
   token.token
 end

--- a/config/initializers/graphiql.rb
+++ b/config/initializers/graphiql.rb
@@ -1,12 +1,8 @@
 # frozen_string_literal: true
 
-# Note:  This is almost certainly an awful practice
-#        because it opens up a hole where anyone can sign in
-#        as this user.  We should do something about this uh eventually.
 def graphiql_doorkeeper_token
-  user = User.find_or_initialize_by(email: 'graphiql-test@trumanshuck.com')
-  user.update!(password: 'hunter222') unless user.persisted?
-
+  user = User.find_by(email: 'a@a.a')
+  return if user.blank?
   token = Doorkeeper::AccessToken.create!(resource_owner_id: user.id, expires_in: nil)
   token.token
 end


### PR DESCRIPTION
Replace inline user create with a seeded user for graphiql.  Add note about graphiql to readme.  Updates user broadcast to include user's name.