### PR TITLE
Upgrade postgres to latest stable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
 
     services:
       postgres:
-        image: postgres:10.8
+        image: postgres:12.1
         env:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: postgrespassword

--- a/bin/setup
+++ b/bin/setup
@@ -7,7 +7,6 @@ include FileUtils # rubocop:disable Style/MixinUsage
 
 # path to your application root.
 APP_ROOT = Pathname.new File.expand_path('..', __dir__)
-PRODLIKE = ENV['PRODLIKE'] == 'true'
 
 def system!(*args)
   system(*args) || abort("\n== Command #{args} failed ==")

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@
 version: '3.4'
 services:
   db:
-    image: postgres:9.5.4
+    image: postgres:12.1
     environment:
       POSTGRES_PASSWORD: postgrespassword
     ports: ["5432:5432"]


### PR DESCRIPTION
@go-between/folks 

This PR upgrades our postgres version (in docker and in the github workflow) to the latest stable **12.1**.

**NOTE!!!!!**
You will have to entirely destroy the old database container.  Simply running `bin/setup` within `musicbox-api` will result in an error like the following:
```
Trumans-MacBook-Pro:musicbox-api trumanshuck$ dc logs -f db
Attaching to musicbox-api_db_1
db_1                   |
db_1                   | PostgreSQL Database directory appears to contain a database; Skipping initialization
db_1                   |
db_1                   | 2020-01-18 05:10:40.337 UTC [1] FATAL:  database files are incompatible with server
db_1                   | 2020-01-18 05:10:40.337 UTC [1] DETAIL:  The data directory was initialized by PostgreSQL version 9.5, which is not compatible with this version 12.1 (Debian 12.1-1.pgdg100+1).
```

**To fix:** execute `docker-compose rm db` in order to clear the old database container _and then_ re-run `bin/setup`.