### PR TITLE
Room an queue

### DIFF
--- a/app/channels/application_cable/channel.rb
+++ b/app/channels/application_cable/channel.rb
@@ -2,7 +2,6 @@
 
 module ApplicationCable
   class Channel < ActionCable::Channel::Base
-
     def subscribe_for_current_user
       return reject if current_user.active_room.blank?
 

--- a/app/channels/application_cable/channel.rb
+++ b/app/channels/application_cable/channel.rb
@@ -2,5 +2,11 @@
 
 module ApplicationCable
   class Channel < ActionCable::Channel::Base
+
+    def subscribe_for_current_user
+      return reject if current_user.active_room.blank?
+
+      stream_for current_user.active_room
+    end
   end
 end

--- a/app/channels/now_playing_channel.rb
+++ b/app/channels/now_playing_channel.rb
@@ -1,8 +1,5 @@
 # frozen_string_literal: true
 
 class NowPlayingChannel < ApplicationCable::Channel
-  def subscribed
-    room = Room.find(params[:room_id])
-    stream_for room
-  end
+  delegate :subscribed, to: :subscribe_for_current_user
 end

--- a/app/channels/room_playlist_channel.rb
+++ b/app/channels/room_playlist_channel.rb
@@ -1,8 +1,5 @@
 # frozen_string_literal: true
 
 class RoomPlaylistChannel < ApplicationCable::Channel
-  def subscribed
-    room = Room.find(params[:room_id])
-    stream_for room
-  end
+  delegate :subscribed, to: :subscribe_for_current_user
 end

--- a/app/channels/room_playlist_channel.rb
+++ b/app/channels/room_playlist_channel.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class QueuesChannel < ApplicationCable::Channel
+class RoomPlaylistChannel < ApplicationCable::Channel
   def subscribed
     room = Room.find(params[:room_id])
     stream_for room

--- a/app/channels/users_channel.rb
+++ b/app/channels/users_channel.rb
@@ -1,9 +1,5 @@
 # frozen_string_literal: true
 
 class UsersChannel < ApplicationCable::Channel
-  def subscribed
-    return reject if current_user.active_room.blank?
-
-    stream_for current_user.active_room
-  end
+  delegate :subscribed, to: :subscribe_for_current_user
 end

--- a/app/workers/broadcast_playlist_worker.rb
+++ b/app/workers/broadcast_playlist_worker.rb
@@ -6,7 +6,7 @@ class BroadcastPlaylistWorker
 
   def perform(room_id)
     queue = MusicboxApiSchema.execute(query: query, variables: { roomId: room_id })
-    QueuesChannel.broadcast_to(Room.find(room_id), queue.to_h)
+    RoomPlaylistChannel.broadcast_to(Room.find(room_id), queue.to_h)
   end
 
   private

--- a/app/workers/broadcast_playlist_worker.rb
+++ b/app/workers/broadcast_playlist_worker.rb
@@ -15,7 +15,7 @@ class BroadcastPlaylistWorker
     %(
       query($roomId: ID!) {
         roomPlaylist(roomId: $roomId) {
-          id, order, song { id, name }, user { email }
+          id, order, song { id, name }, user { email, name }
         }
       }
     )

--- a/spec/integration/requests_spec.rb
+++ b/spec/integration/requests_spec.rb
@@ -102,7 +102,7 @@ RSpec.describe "Requests Integration", type: :request do
           query: room_playlist_records_reorder_mutation(records: records),
           user: dan
         )
-      end.to(broadcast_to(QueuesChannel.broadcasting_for(room)).with do |data|
+      end.to(broadcast_to(RoomPlaylistChannel.broadcasting_for(room)).with do |data|
         songs = data.dig("data", "roomPlaylist")
         expect(songs.size).to eq(1)
 
@@ -126,7 +126,7 @@ RSpec.describe "Requests Integration", type: :request do
           query: room_playlist_records_reorder_mutation(records: records),
           user: dan
         )
-      end.to(broadcast_to(QueuesChannel.broadcasting_for(room)).with do |data|
+      end.to(broadcast_to(RoomPlaylistChannel.broadcasting_for(room)).with do |data|
         songs = data.dig("data", "roomPlaylist")
         expect(songs.size).to eq(2)
 
@@ -148,7 +148,7 @@ RSpec.describe "Requests Integration", type: :request do
           query: room_playlist_records_reorder_mutation(records: records),
           user: truman
         )
-      end.to(broadcast_to(QueuesChannel.broadcasting_for(room)).with do |data|
+      end.to(broadcast_to(RoomPlaylistChannel.broadcasting_for(room)).with do |data|
         songs = data.dig("data", "roomPlaylist")
         expect(songs.size).to eq(3)
         expect(songs.first["id"]).to eq(dan_unicorn_id)
@@ -175,7 +175,7 @@ RSpec.describe "Requests Integration", type: :request do
           query: room_playlist_records_reorder_mutation(records: records),
           user: sean
         )
-      end.to(broadcast_to(QueuesChannel.broadcasting_for(room)).with do |data|
+      end.to(broadcast_to(RoomPlaylistChannel.broadcasting_for(room)).with do |data|
         songs = data.dig("data", "roomPlaylist")
         expect(songs.size).to eq(4)
 
@@ -205,7 +205,7 @@ RSpec.describe "Requests Integration", type: :request do
           query: room_playlist_records_reorder_mutation(records: records),
           user: sean
         )
-      end.to(broadcast_to(QueuesChannel.broadcasting_for(room)).with do |data|
+      end.to(broadcast_to(RoomPlaylistChannel.broadcasting_for(room)).with do |data|
         songs = data.dig("data", "roomPlaylist")
         expect(songs.size).to eq(5)
 
@@ -234,7 +234,7 @@ RSpec.describe "Requests Integration", type: :request do
           query: room_playlist_records_reorder_mutation(records: records),
           user: truman
         )
-      end.to(broadcast_to(QueuesChannel.broadcasting_for(room)).with do |data|
+      end.to(broadcast_to(RoomPlaylistChannel.broadcasting_for(room)).with do |data|
         songs = data.dig("data", "roomPlaylist")
         expect(songs.size).to eq(6)
 

--- a/spec/workers/broadcast_playlist_worker_spec.rb
+++ b/spec/workers/broadcast_playlist_worker_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe BroadcastPlaylistWorker, type: :worker do
 
       expect do
         worker.perform(room.id)
-      end.to(have_broadcasted_to(room).from_channel(QueuesChannel).with do |msg|
+      end.to(have_broadcasted_to(room).from_channel(RoomPlaylistChannel).with do |msg|
         songs = msg.dig(:data, :roomPlaylist)
 
         expect(songs.dig(0, :id)).to eq(user1_record1.id)


### PR DESCRIPTION
@go-between/folks 

Updates old `QueuesChannel` to hopefully more helpful `RoomPlaylistChannel`.  Extracts common subscription method to the channel base class.  Allows room playlist broadcast to send user's name.