### PR TITLE
Allow reorder mutation to remove missing records

### DIFF
--- a/app/graphql/mutations/room_playlist_records_reorder.rb
+++ b/app/graphql/mutations/room_playlist_records_reorder.rb
@@ -13,16 +13,14 @@ module Mutations
     field :errors, [String], null: true
 
     def resolve(ordered_records:)
-      room = Room.find(context[:current_user].active_room_id)
-
-      ensure_user_in_rotation!(room)
-
       @errors = []
+      ensure_user_in_rotation!
 
-      records = initialize_records!(room.id, ordered_records)
+      records = initialize_records!(ordered_records)
+      destroy_absent_records!(records)
+
       records.each_with_index { |r, i| r.update!(order: i) }
-
-      BroadcastPlaylistWorker.perform_async(room.id)
+      BroadcastPlaylistWorker.perform_async(current_user.active_room_id)
 
       {
         room_playlist_records: records,
@@ -32,22 +30,31 @@ module Mutations
 
     private
 
-    def ensure_user_in_rotation!(room)
+    def ensure_user_in_rotation!
+      room = Room.find(current_user.active_room_id)
       room.with_lock do
-        return if room.user_rotation.include?(context[:current_user].id)
+        return if room.user_rotation.include?(current_user.id)
 
-        rotation = room.user_rotation << context[:current_user].id
+        rotation = room.user_rotation << current_user.id
 
         room.update!(user_rotation: rotation)
       end
     end
 
-    def initialize_records!(room_id, ordered_records)
+    def destroy_absent_records!(records)
+      t = RoomPlaylistRecord.arel_table
+      RoomPlaylistRecord
+        .where(user: current_user, room_id: current_user.active_room_id)
+        .waiting
+        .where(t[:id].not_in(records.map(&:id)))
+        .destroy_all
+    end
+
+    def initialize_records!(ordered_records)
       ordered_records.map do |ordered_record, _index|
         record = initialize_record!(
           ordered_record[:room_playlist_record_id],
-          ordered_record[:song_id],
-          room_id
+          ordered_record[:song_id]
         )
 
         unless record
@@ -62,20 +69,20 @@ module Mutations
       end.compact
     end
 
-    def initialize_record!(room_playlist_record_id, song_id, room_id)
+    def initialize_record!(room_playlist_record_id, song_id)
       if room_playlist_record_id.present?
         RoomPlaylistRecord.find_by(
           id: room_playlist_record_id,
-          user: context[:current_user],
+          user: current_user,
           play_state: :waiting
         )
       else
         return unless Song.exists?(id: song_id)
 
         RoomPlaylistRecord.create!(
-          room_id: room_id,
+          room_id: current_user.active_room_id,
           song_id: song_id,
-          user: context[:current_user],
+          user: current_user,
           play_state: :waiting
         )
       end

--- a/app/graphql/mutations/user_library_record_delete.rb
+++ b/app/graphql/mutations/user_library_record_delete.rb
@@ -7,7 +7,7 @@ module Mutations
     field :errors, [String], null: true
 
     def resolve(id:)
-      record = UserLibraryRecord.find_by(id: id, user: context[:current_user])
+      record = UserLibraryRecord.find_by(song_id: id, user: context[:current_user])
       return { errors: ["Can't find song to delete"] } if record.blank?
 
       record.destroy!

--- a/spec/mutations/user_library_record_delete_spec.rb
+++ b/spec/mutations/user_library_record_delete_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe "User Library Record Delete", type: :request do
       record = create(:user_library_record, user: current_user)
 
       graphql_request(
-        query: query(id: record.id),
+        query: query(id: record.song.id),
         user: current_user
       )
       data = json_body.dig(:data, :userLibraryRecordDelete)
@@ -40,7 +40,7 @@ RSpec.describe "User Library Record Delete", type: :request do
       record = create(:user_library_record, user: create(:user))
 
       graphql_request(
-        query: query(id: record.id),
+        query: query(id: record.song.id),
         user: current_user
       )
       data = json_body.dig(:data, :userLibraryRecordDelete)


### PR DESCRIPTION
@go-between/folks 

Allows the `reorder` mutation to remove playlist records that do not appear in a new ordering request.  Updates the user library delete mutation to delete by song id instead of user-library id.
