### PR TITLE
Chit chat

### DIFF
--- a/app/channels/message_channel.rb
+++ b/app/channels/message_channel.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+class MessageChannel < ApplicationCable::Channel
+  delegate :subscribed, to: :subscribe_for_current_user
+end

--- a/app/graphql/mutations/message_create.rb
+++ b/app/graphql/mutations/message_create.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+module Mutations
+  class MessageCreate < Mutations::BaseMutation
+    argument :message, String, required: true
+
+    field :message, Types::MessageType, null: true
+    field :errors, [String], null: true
+
+    def resolve(message:)
+      unless current_user.active_room_id.present?
+        return {
+          message: nil,
+          errors: ["Must be in an active room"]
+        }
+      end
+
+      {
+        message: create_message!(message),
+        errors: []
+      }
+    end
+
+    private
+
+    def create_message!(message)
+      Message.create!(
+        message: message,
+        room_playlist_record: current_user.active_room.current_record,
+        room_id: current_user.active_room_id,
+        user_id: current_user.id
+      )
+    end
+  end
+end

--- a/app/graphql/mutations/message_create.rb
+++ b/app/graphql/mutations/message_create.rb
@@ -15,8 +15,11 @@ module Mutations
         }
       end
 
+      new_message = create_message!(message)
+      BroadcastMessageWorker.perform_async(current_user.active_room_id, new_message.id)
+
       {
-        message: create_message!(message),
+        message: new_message,
         errors: []
       }
     end

--- a/app/graphql/types/message_type.rb
+++ b/app/graphql/types/message_type.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module Types
+  class MessageType < Types::BaseObject
+    graphql_name "Message"
+
+    field :id, ID, null: false
+    field :message, String, null: false
+    field :created_at, Types::DateTimeType, null: false
+
+    field :room_playlist_record, Types::RoomPlaylistRecordType, null: true
+    field :room, Types::RoomType, null: false
+    field :user, Types::UserType, null: false
+  end
+end

--- a/app/graphql/types/mutation_type.rb
+++ b/app/graphql/types/mutation_type.rb
@@ -5,6 +5,8 @@ module Types
     field :invitation_accept, mutation: Mutations::InvitationAccept
     field :invitation_create, mutation: Mutations::InvitationCreate
 
+    field :message_create, mutation: Mutations::MessageCreate
+
     field :room_activate, mutation: Mutations::RoomActivate
     field :room_create, mutation: Mutations::RoomCreate
 

--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -4,6 +4,22 @@ module Types
   class QueryType < Types::BaseObject
     graphql_name "Query"
 
+    field :messages, [Types::MessageType], null: false do
+      argument :from, Types::DateTimeType, required: false
+      argument :to, Types::DateTimeType, required: false
+    end
+
+    def messages(from: nil, to: nil) # rubocop:disable Metrics/AbcSize
+      return [] if current_user.active_room.blank?
+
+      t = Message.arel_table
+      messages = Message.where(room_id: current_user.active_room_id)
+      messages = messages.where(t[:created_at].gteq(from)) if from.present?
+      messages = messages.where(t[:created_at].lteq(to)) if to.present?
+
+      messages.order(created_at: :asc)
+    end
+
     field :room, Types::RoomType, null: true do
       argument :id, ID, required: true
     end

--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -4,6 +4,14 @@ module Types
   class QueryType < Types::BaseObject
     graphql_name "Query"
 
+    field :message, Types::MessageType, null: false do
+      argument :id, ID, required: true
+    end
+
+    def message(id:)
+      Message.find(id)
+    end
+
     field :messages, [Types::MessageType], null: false do
       argument :from, Types::DateTimeType, required: false
       argument :to, Types::DateTimeType, required: false

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class Message < ApplicationRecord
+  belongs_to :room_playlist_record, optional: true
+  belongs_to :room
+  belongs_to :user
+end

--- a/app/workers/broadcast_message_worker.rb
+++ b/app/workers/broadcast_message_worker.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+class BroadcastMessageWorker
+  include Sidekiq::Worker
+  sidekiq_options queue: "broadcast_message"
+
+  def perform(room_id, message_id)
+    queue = MusicboxApiSchema.execute(query: query, variables: { id: message_id })
+    MessageChannel.broadcast_to(Room.find(room_id), queue.to_h)
+  end
+
+  private
+
+  def query # rubocop:disable Metrics/MethodLength
+    %(
+      query($id: ID!) {
+        message(id: $id) {
+          message
+          createdAt
+          roomPlaylistRecord {
+            song {
+              name
+            }
+          }
+          user {
+            name
+          }
+        }
+      }
+    )
+  end
+end

--- a/app/workers/broadcast_now_playing_worker.rb
+++ b/app/workers/broadcast_now_playing_worker.rb
@@ -2,7 +2,7 @@
 
 class BroadcastNowPlayingWorker
   include Sidekiq::Worker
-  sidekiq_options queue: "websocket_broadcast"
+  sidekiq_options queue: "broadcast_now_playing"
 
   def perform(room_id)
     now_playing = MusicboxApiSchema.execute(query: query, variables: { id: room_id })

--- a/app/workers/broadcast_playlist_worker.rb
+++ b/app/workers/broadcast_playlist_worker.rb
@@ -2,7 +2,7 @@
 
 class BroadcastPlaylistWorker
   include Sidekiq::Worker
-  sidekiq_options queue: "websocket_broadcast"
+  sidekiq_options queue: "broadcast_playlist"
 
   def perform(room_id)
     queue = MusicboxApiSchema.execute(query: query, variables: { roomId: room_id })

--- a/app/workers/broadcast_users_worker.rb
+++ b/app/workers/broadcast_users_worker.rb
@@ -2,7 +2,7 @@
 
 class BroadcastUsersWorker
   include Sidekiq::Worker
-  sidekiq_options queue: "websocket_broadcast"
+  sidekiq_options queue: "broadcast_users"
 
   def perform(room_id)
     queue = MusicboxApiSchema.execute(query: query, variables: { id: room_id })

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -3,4 +3,7 @@
 :timeout: 8
 :queues:
   - [queue_management, 1]
-  - [websocket_broadcast, 1]
+  - [broadcast_message, 1]
+  - [broadcast_now_playing, 1]
+  - [broadcast_playlist, 1]
+  - [broadcast_users, 1]

--- a/db/migrate/20200125023143_create_messages.rb
+++ b/db/migrate/20200125023143_create_messages.rb
@@ -1,0 +1,14 @@
+class CreateMessages < ActiveRecord::Migration[6.0]
+  def change
+    create_table :messages, id: :uuid do |t|
+      t.string :message
+      t.uuid :room_playlist_record_id
+      t.uuid :room_id
+      t.uuid :user_id
+      t.timestamps
+
+      t.index :room_id
+      t.index :created_at
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_01_02_170036) do
+ActiveRecord::Schema.define(version: 2020_01_25_023143) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -25,6 +25,17 @@ ActiveRecord::Schema.define(version: 2020_01_02_170036) do
     t.datetime "updated_at", precision: 6, null: false
     t.string "invitation_state"
     t.index ["token"], name: "index_invitations_on_token"
+  end
+
+  create_table "messages", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.string "message"
+    t.uuid "room_playlist_record_id"
+    t.uuid "room_id"
+    t.uuid "user_id"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["created_at"], name: "index_messages_on_created_at"
+    t.index ["room_id"], name: "index_messages_on_room_id"
   end
 
   create_table "oauth_access_grants", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,4 +27,4 @@ services:
     environment:
       <<: *app-environment
       DB_POOL: 1
-      SIDEKIQ_CONCURRENCY: 1
+      SIDEKIQ_CONCURRENCY: 5

--- a/spec/factories/message.rb
+++ b/spec/factories/message.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :message do
+    message { "Hey Friend" }
+    created_at { Time.zone.now }
+    room_playlist_record { nil }
+    room
+    user
+  end
+end

--- a/spec/models/message_spec.rb
+++ b/spec/models/message_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Message, type: :model do
+  describe "relationships" do
+    let(:room) { create(:room) }
+    let(:user) { create(:user) }
+    let(:room_playlist_record) { create(:room_playlist_record, room: room, user: user) }
+
+    it "may belong to a room, user, and playlist record" do
+      message = described_class.create!(
+        message: "hi",
+        room_playlist_record: room_playlist_record,
+        room: room,
+        user: user
+      )
+
+      expect(message.room_playlist_record).to eq(room_playlist_record)
+      expect(message.room).to eq(room)
+      expect(message.user).to eq(user)
+    end
+
+    it "does not require a room room_playlist_record" do
+      message = described_class.create!(message: "hi", room: room, user: user)
+
+      expect(message).to be_persisted
+      expect(message.room_playlist_record).to be_nil
+    end
+  end
+end

--- a/spec/mutations/message_create_spec.rb
+++ b/spec/mutations/message_create_spec.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Invitation Create", type: :request do
+  include AuthHelper
+  include JsonHelper
+
+  def query
+    %(
+      mutation MessageCreate($message: String!) {
+        messageCreate(input: {
+          message: $message
+        }) {
+          message {
+            id
+          }
+          errors
+        }
+      }
+    )
+  end
+
+  let(:room_playlist_record) { create(:room_playlist_record) }
+  let(:room) { create(:room, current_record: room_playlist_record) }
+  let(:current_user) { create(:user, active_room: room) }
+
+  describe "success" do
+    it "creates a new message" do
+      graphql_request(query: query, variables: { message: "Heyo" }, user: current_user)
+      id = json_body.dig(:data, :messageCreate, :message, :id)
+
+      message = Message.find(id)
+      expect(message.room_playlist_record).to eq(room_playlist_record)
+      expect(message.room).to eq(room)
+      expect(message.user).to eq(current_user)
+    end
+  end
+
+  describe "failure" do
+    it "does not create a message when user is not in a room" do
+      current_user.update!(active_room_id: nil)
+      expect do
+        graphql_request(query: query, variables: { message: "Heyo" }, user: current_user)
+      end.to not_change(Message, :count)
+    end
+  end
+end

--- a/spec/mutations/message_create_spec.rb
+++ b/spec/mutations/message_create_spec.rb
@@ -35,6 +35,13 @@ RSpec.describe "Invitation Create", type: :request do
       expect(message.room).to eq(room)
       expect(message.user).to eq(current_user)
     end
+
+    it "enqueues a broadcast" do
+      graphql_request(query: query, variables: { message: "Heyo" }, user: current_user)
+      id = json_body.dig(:data, :messageCreate, :message, :id)
+
+      expect(BroadcastMessageWorker).to have_enqueued_sidekiq_job(room.id, id)
+    end
   end
 
   describe "failure" do

--- a/spec/queries/messages_spec.rb
+++ b/spec/queries/messages_spec.rb
@@ -1,0 +1,103 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Room Query", type: :request do
+  include AuthHelper
+  include JsonHelper
+
+  def query
+    %(
+      query Messages($from: DateTime, $to: DateTime) {
+        messages(from: $from, to: $to) {
+          id
+          message
+          room {
+            id
+          }
+          user {
+            id
+          }
+          roomPlaylistRecord {
+            id
+          }
+        }
+      }
+    )
+  end
+
+  let(:room) { create(:room) }
+  let(:user) { create(:user, active_room: room) }
+  let(:user2) { create(:user, active_room: room) }
+  let(:room_playlist_record) { create(:room_playlist_record, room: room) }
+
+  # rubocop:disable RSpec/LetSetup
+  let!(:message1) do
+    create(
+      :message,
+      room: room,
+      user: user,
+      created_at: 5.hours.ago,
+      room_playlist_record: room_playlist_record
+    )
+  end
+  let!(:message2) { create(:message, room: room, user: user2, created_at: 3.hours.ago) }
+  let!(:message3) { create(:message, room: room, user: user, created_at: 1.hour.ago) }
+  let!(:other_message) { create(:message, room: create(:room), user: user2, created_at: 3.hours.ago) }
+  # rubocop:enable RSpec/LetSetup
+
+  describe "query" do
+    it "returns ordered messages for the user's active room" do
+      graphql_request(query: query, user: user)
+
+      expect(json_body.dig(:data, :messages).size).to eq(3)
+      message1_body = json_body.dig(:data, :messages, 0)
+      expect(message1_body[:id]).to eq(message1.id)
+      expect(message1_body.dig(:roomPlaylistRecord, :id)).to eq(room_playlist_record.id)
+      expect(message1_body.dig(:room, :id)).to eq(room.id)
+      expect(message1_body.dig(:user, :id)).to eq(user.id)
+
+      message2_body = json_body.dig(:data, :messages, 1)
+      expect(message2_body[:id]).to eq(message2.id)
+      expect(message2_body.dig(:roomPlaylistRecord)).to be_nil
+      expect(message2_body.dig(:room, :id)).to eq(room.id)
+      expect(message2_body.dig(:user, :id)).to eq(user2.id)
+
+      message3_body = json_body.dig(:data, :messages, 2)
+      expect(message3_body[:id]).to eq(message3.id)
+      expect(message3_body.dig(:roomPlaylistRecord)).to be_nil
+      expect(message3_body.dig(:room, :id)).to eq(room.id)
+      expect(message3_body.dig(:user, :id)).to eq(user.id)
+    end
+
+    it "returns no messages if the user is not in an active room" do
+      user.update!(active_room_id: nil)
+      graphql_request(query: query, user: user)
+
+      expect(json_body.dig(:data, :messages)).to be_empty
+    end
+  end
+
+  describe "filtering" do
+    it "returns messages after the specified datetime" do
+      graphql_request(query: query, variables: { from: 4.hours.ago }, user: user)
+
+      message_ids = json_body.dig(:data, :messages).map { |m| m[:id] }
+      expect(message_ids).to match_array([message2.id, message3.id])
+    end
+
+    it "returns messages before the specified datetime" do
+      graphql_request(query: query, variables: { to: 2.hours.ago }, user: user)
+
+      message_ids = json_body.dig(:data, :messages).map { |m| m[:id] }
+      expect(message_ids).to match_array([message1.id, message2.id])
+    end
+
+    it "returns messages between the specified datetimes" do
+      graphql_request(query: query, variables: { from: 4.hours.ago, to: 2.hours.ago }, user: user)
+
+      message_ids = json_body.dig(:data, :messages).map { |m| m[:id] }
+      expect(message_ids).to match_array([message2.id])
+    end
+  end
+end

--- a/spec/support/auth_helper.rb
+++ b/spec/support/auth_helper.rb
@@ -14,8 +14,8 @@ module AuthHelper
     @_token[user] = Doorkeeper::AccessToken.create!(resource_owner_id: user.id)
   end
 
-  def graphql_request(query:, headers: {}, user: create(:user))
-    post("/api/v1/graphql", params: { query: query }, headers: headers.merge(auth_headers(user)))
+  def graphql_request(query:, variables: {}, headers: {}, user: create(:user))
+    post("/api/v1/graphql", params: { query: query, variables: variables }, headers: headers.merge(auth_headers(user)))
   end
 
   def authed_post(url:, body:, headers: {}, user:)

--- a/spec/workers/broadcast_message_worker_spec.rb
+++ b/spec/workers/broadcast_message_worker_spec.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+RSpec.describe BroadcastMessageWorker, type: :worker do
+  let(:created_at) { Time.zone.now }
+  let(:room) { create(:room) }
+  let(:user) { create(:user, name: "Jorm") }
+  let(:room_playlist_record) { create(:room_playlist_record) }
+  let(:worker) { described_class.new }
+
+  describe "#perform" do
+    it "broadcasts a message" do
+      message = Message.create!(
+        message: "Howdy folks",
+        room_playlist_record: room_playlist_record,
+        room: room,
+        user: user,
+        created_at: created_at
+      )
+
+      expect do
+        worker.perform(room.id, message.id)
+      end.to(have_broadcasted_to(room).from_channel(MessageChannel).with do |msg|
+        data = msg.dig(:data, :message)
+        expect(data[:message]).to eq("Howdy folks")
+        expect(data[:createdAt]).to eq(created_at.iso8601)
+        expect(data.dig(:roomPlaylistRecord, :song, :name)).to eq(room_playlist_record.song.name)
+        expect(data.dig(:user, :name)).to eq("Jorm")
+      end)
+    end
+  end
+end


### PR DESCRIPTION
@go-between/folks 

Allows messages to be a thing.  A message is tied to a user and the room that it was sent to, and is optionally associated with whatever playlist record is currently being played.

Also updates `graphql_helper` to accept variables so that we don't have to string interpolate variables anymore.  Also updates various broadcast workers to use their own sidekiq queues so that we can scale them individually.  You may need to `docker-compose kill && docker-compose up -d` to see that change.