### PR TITLE
Drop database version to 11.5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
 
     services:
       postgres:
-        image: postgres:12.1
+        image: postgres:11.5
         env:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: postgrespassword

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@
 version: '3.4'
 services:
   db:
-    image: postgres:12.1
+    image: postgres:11.5
     environment:
       POSTGRES_PASSWORD: postgrespassword
     ports: ["5432:5432"]


### PR DESCRIPTION
@go-between/folks 

Drops Postgres to 11.5 because RDS doesn't support 12 in non-experimental mode yet. See instructions from #53 if you have trouble bringing the database up after this change.