### PR TITLE
Event loopin

### DIFF
--- a/app/graphql/mutations/room_playlist_records_reorder.rb
+++ b/app/graphql/mutations/room_playlist_records_reorder.rb
@@ -14,7 +14,7 @@ module Mutations
 
     def resolve(ordered_records:)
       @errors = []
-      ensure_user_in_rotation!
+      ensure_room_state!
 
       records = initialize_records!(ordered_records)
       destroy_absent_records!(records)
@@ -30,13 +30,13 @@ module Mutations
 
     private
 
-    def ensure_user_in_rotation!
+    def ensure_room_state!
       room = Room.find(current_user.active_room_id)
       room.with_lock do
+        room.update!(waiting_songs: true)
         return if room.user_rotation.include?(current_user.id)
 
         rotation = room.user_rotation << current_user.id
-
         room.update!(user_rotation: rotation)
       end
     end

--- a/app/lib/poll_room_queue.rb
+++ b/app/lib/poll_room_queue.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+class PollRoomQueue
+  def initialize
+    @room_arel = Room.arel_table
+  end
+
+  def poll!
+    rooms_to_enqueue = recently_finished_playing.or(newly_enqueued)
+    rooms_to_enqueue.each do |room|
+      enqueue_for(room.id)
+    end
+  end
+
+  private
+
+  def newly_enqueued
+    Room.where(playing_until: nil).where(waiting_songs: true)
+  end
+
+  def recently_finished_playing
+    Room.where(@room_arel[:playing_until].lteq(Time.zone.now))
+  end
+
+  def enqueue_for(room_id)
+    QueueManagementWorker.perform_async(room_id)
+  end
+end

--- a/app/workers/queue_management_worker.rb
+++ b/app/workers/queue_management_worker.rb
@@ -5,32 +5,33 @@ class QueueManagementWorker
   sidekiq_options queue: "queue_management"
 
   def perform(room_id) # rubocop:disable Metrics/AbcSize
-    playlist = RoomPlaylist.new(room_id).generate_playlist
-
-    next_record = playlist[0]
-    return empty_queue!(room_id) if next_record.blank?
-
-    next_record.update!(play_state: "played", played_at: Time.zone.now)
-
-    Room.find(room_id).update!(current_record: next_record)
-
-    BroadcastNowPlayingWorker.perform_async(room_id)
-    BroadcastPlaylistWorker.perform_async(room_id)
-    self.class.perform_in(next_record.song.duration_in_seconds, room_id)
-  end
-
-  private
-
-  def empty_queue!(room_id)
     room = Room.find(room_id)
+    room.with_lock do
+      return if room.playing_until&.future?
 
-    if room.current_record.present?
-      room.update!(current_record: nil)
+      playlist = RoomPlaylist.new(room_id).generate_playlist
+
+      next_record = playlist.first
+      return idle!(room) if next_record.blank?
+
+      next_record.update!(play_state: "played", played_at: Time.zone.now)
+      playing_until = next_record.song.duration_in_seconds.seconds.from_now
+      room.update!(current_record: next_record, playing_until: playing_until)
 
       BroadcastNowPlayingWorker.perform_async(room_id)
       BroadcastPlaylistWorker.perform_async(room_id)
     end
+  end
 
-    self.class.perform_in(1.second, room_id)
+  private
+
+  def idle!(room)
+    just_finished = room.current_record.present?
+    room.update!(current_record: nil, playing_until: nil, waiting_songs: false)
+
+    return unless just_finished
+
+    BroadcastNowPlayingWorker.perform_async(room.id)
+    BroadcastPlaylistWorker.perform_async(room.id)
   end
 end

--- a/db/migrate/20200205052424_add_playing_until_to_room.rb
+++ b/db/migrate/20200205052424_add_playing_until_to_room.rb
@@ -1,0 +1,6 @@
+class AddPlayingUntilToRoom < ActiveRecord::Migration[6.0]
+  def change
+    add_column :rooms, :playing_until, :datetime
+    add_index :rooms, :playing_until
+  end
+end

--- a/db/migrate/20200205061306_add_waiting_songs_to_room.rb
+++ b/db/migrate/20200205061306_add_waiting_songs_to_room.rb
@@ -1,0 +1,5 @@
+class AddWaitingSongsToRoom < ActiveRecord::Migration[6.0]
+  def change
+    add_column :rooms, :waiting_songs, :boolean
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_01_25_023143) do
+ActiveRecord::Schema.define(version: 2020_02_05_052424) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -99,6 +99,8 @@ ActiveRecord::Schema.define(version: 2020_01_25_023143) do
     t.uuid "current_record_id"
     t.uuid "user_rotation", default: [], array: true
     t.uuid "team_id"
+    t.datetime "playing_until"
+    t.index ["playing_until"], name: "index_rooms_on_playing_until"
   end
 
   create_table "songs", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_02_05_052424) do
+ActiveRecord::Schema.define(version: 2020_02_05_061306) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -100,6 +100,7 @@ ActiveRecord::Schema.define(version: 2020_02_05_052424) do
     t.uuid "user_rotation", default: [], array: true
     t.uuid "team_id"
     t.datetime "playing_until"
+    t.boolean "waiting_songs"
     t.index ["playing_until"], name: "index_rooms_on_playing_until"
   end
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,6 +20,10 @@ services:
   redis:
     image: redis:5.0.3
     ports: ["6379:6379"]
+  app-poll-room-queue:
+    <<: *app-common
+    command: bin/wait-for-it.sh db:5432 -- bin/wait-for-it.sh redis:6379 -- rake room:poll_queue
+    ports: []
   app-sidekiq-workers:
     <<: *app-common
     command: bin/wait-for-it.sh db:5432 -- bin/wait-for-it.sh redis:6379 -- bundle exec sidekiq

--- a/lib/tasks/room.rake
+++ b/lib/tasks/room.rake
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+namespace :room do
+  desc "Starts loop to poll all rooms for new songs to play"
+  task poll_queue: :environment do
+    poller = PollRoomQueue.new
+
+    loop do
+      poller.poll!
+      sleep(0.1)
+    end
+  end
+end

--- a/spec/factories/room.rb
+++ b/spec/factories/room.rb
@@ -4,6 +4,8 @@ FactoryBot.define do
   factory :room do
     name { "Banjo Town" }
     current_record { nil }
+    playing_until { nil }
+    waiting_songs { false }
     team
   end
 end

--- a/spec/lib/poll_room_queue_spec.rb
+++ b/spec/lib/poll_room_queue_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe PollRoomQueue do
+  describe "#poll!" do
+    it "enqueues queue updates for pertinent rooms" do
+      # Not done playing yet
+      not_done = create(:room, playing_until: 1.minute.from_now)
+      # No songs waiting to be played
+      none_waiting = create(:room, playing_until: nil, waiting_songs: false)
+
+      recently_finished1 = create(:room, playing_until: 1.second.ago)
+      recently_finished2 = create(:room, playing_until: 1.minute.ago)
+      with_waiting_song1 = create(:room, playing_until: nil, waiting_songs: true)
+      with_waiting_song2 = create(:room, playing_until: nil, waiting_songs: true)
+
+      poller = described_class.new
+      poller.poll!
+
+      expect(QueueManagementWorker).not_to have_enqueued_sidekiq_job(not_done.id)
+      expect(QueueManagementWorker).not_to have_enqueued_sidekiq_job(none_waiting.id)
+      expect(QueueManagementWorker).to have_enqueued_sidekiq_job(recently_finished1.id)
+      expect(QueueManagementWorker).to have_enqueued_sidekiq_job(recently_finished2.id)
+      expect(QueueManagementWorker).to have_enqueued_sidekiq_job(with_waiting_song1.id)
+      expect(QueueManagementWorker).to have_enqueued_sidekiq_job(with_waiting_song2.id)
+    end
+  end
+end

--- a/spec/mutations/room_playlist_records_reorder_spec.rb
+++ b/spec/mutations/room_playlist_records_reorder_spec.rb
@@ -10,6 +10,23 @@ RSpec.describe "Room Playlist Records Reorder", type: :request do
   let(:room) { create(:room) }
   let(:current_user) { create(:user, active_room_id: room.id) }
 
+  describe "waiting song state" do
+    it "indicates that the room has songs waiting to be played" do
+      room.update!(waiting_songs: false)
+      record1 = create(:room_playlist_record, room: room, order: 0, user: current_user)
+
+      records = [
+        { song_id: record1.song_id, room_playlist_record_id: record1.id }
+      ]
+      graphql_request(
+        query: room_playlist_records_reorder_mutation(records: records),
+        user: current_user
+      )
+
+      expect(room.reload.waiting_songs).to eq(true)
+    end
+  end
+
   describe "song ordering" do
     it "reorders existing records" do
       record1 = create(:room_playlist_record, room: room, order: 0, user: current_user)

--- a/spec/workers/queue_management_worker_spec.rb
+++ b/spec/workers/queue_management_worker_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe QueueManagementWorker, type: :worker do
   include ActiveSupport::Testing::TimeHelpers
 
   let(:started) { Time.zone.now }
-  let(:song) { create(:song) }
+  let(:song) { create(:song, duration_in_seconds: 10) }
   let(:room) { create(:room) }
   let(:user) { create(:user) }
   let(:worker) { described_class.new }
@@ -17,11 +17,8 @@ RSpec.describe QueueManagementWorker, type: :worker do
 
       room.reload
       expect(room.current_record).to eq(nil)
-    end
-
-    it "re-queues a new worker" do
-      expect(described_class).to receive(:perform_in).with(1.second, room.id)
-      worker.perform(room.id)
+      expect(room.playing_until).to eq(nil)
+      expect(room.waiting_songs).to eq(false)
     end
 
     context "when its previous run processed the last song" do
@@ -66,6 +63,19 @@ RSpec.describe QueueManagementWorker, type: :worker do
              play_state: "waiting")
     end
 
+    it "does nothing if already playing" do
+      previous_record = create(:room_playlist_record, user: user)
+      playing_until = 1.minute.from_now
+      room.update!(playing_until: playing_until, current_record: previous_record)
+      worker.perform(room.id)
+
+      room.reload
+      expect(room.current_record).to eq(previous_record)
+      expect(room.playing_until).to eq(playing_until)
+      expect(BroadcastNowPlayingWorker).not_to have_enqueued_sidekiq_job(room.id)
+      expect(BroadcastPlaylistWorker).not_to have_enqueued_sidekiq_job(room.id)
+    end
+
     it "updates the room's current record" do
       worker.perform(room.id)
 
@@ -83,11 +93,13 @@ RSpec.describe QueueManagementWorker, type: :worker do
       expect(room.current_record).to be_played
     end
 
-    it "re-enqueues a new worker" do
-      song.update!(duration_in_seconds: 432)
+    it "sets the room's playing until to the song's duration" do
+      travel_to(Time.utc(3000, 1, 1, 0, 0, 0)) do
+        worker.perform(room.id)
+      end
 
-      expect(described_class).to receive(:perform_in).with(432.second, room.id)
-      worker.perform(room.id)
+      room.reload
+      expect(room.playing_until).to eq("3000-01-01 00:00:10.000000000 +0000")
     end
 
     it "broadcasts to queue" do


### PR DESCRIPTION
@go-between/folks 

After listening to a pretty [dope podcast](https://www.maintainable.fm/episodes/mike-perham-how-developers-underestimate-long-term-costs-of-external-dependencies) with Mike Perham, I've finally taken the hint that having the `QueueManagementWorker` reschedule itself continually is a bad pattern -- especially because we have no good way to kick off and monitor each worker for each room that should be running.

Instead, we move to a polling uh event loop sort of thing.  `PollRoomQueue` now loops through all of the rooms that either just finished playing or that were previously idle and enqueues new `QueueManagementWorker`s for each.  This then kicks off the management process where we go figure out what to play next and let everyone know.

We've added a rake task with a sort-of-arbitrary tenth-second sleep between loops, and have added an invocation of the task to our docker-compose.  Running `bin/setup` should now bring that up and newly-enqueued songs will AUTOMATICALLY PLAY LIKE MAGIC WHOA.