### PR TITLE
Allow a user to create a team

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -16,8 +16,11 @@ class ApplicationController < ActionController::API
     #        when we accept an invitation.  But I'd prefer not to push auth
     #        down in to every query/mutation, and I'd prefer not to support
     #        a separate api resource just for accepting invitations.
+    # Note:  Yeah but it's the rule of THREES so one more of these and then
+    #        we'll figure out what to do instead of this.
     graphql_query = params[:query].gsub(/\s+/, "")
-    return if graphql_query[0..25] == "mutation{invitationAccept("
+    return if /^mutation.*\{invitationAccept/ =~ graphql_query
+    return if /^mutation.*\{teamCreate/ =~ graphql_query
 
     doorkeeper_authorize!
   end

--- a/app/graphql/mutations/team_create.rb
+++ b/app/graphql/mutations/team_create.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+module Mutations
+  class TeamCreate < Mutations::BaseMutation
+    class TeamOwnerInputObject < Types::BaseInputObject
+      argument :email, String, required: true
+      argument :name, String, required: true
+      argument :password, String, required: true
+    end
+
+    argument :team_owner, TeamOwnerInputObject, required: true
+    argument :team_name, String, required: true
+    field :access_token, ID, null: true
+    field :errors, [String], null: true
+
+    def resolve(team_owner:, team_name:)
+      # Note:  Presumably we also will accept a billing object
+      #        and ensure that it contains a valid payment mechanism
+      #        before allowing the rest of this to happen.
+      team_owner = ensure_user!(team_owner)
+      return { errors: ["Unable to authenticate user"] } if team_owner.blank?
+
+      team = Team.create!(name: team_name, owner: team_owner)
+      team_owner.teams << team
+
+      {
+        access_token: access_token_for(team_owner.id),
+        errors: []
+      }
+    end
+
+    private
+
+    def access_token_for(user_id)
+      Doorkeeper::AccessToken.create!(
+        resource_owner_id: user_id,
+        expires_in: Doorkeeper.configuration.access_token_expires_in.to_i,
+        scopes: ""
+      ).token
+    end
+
+    def ensure_user!(email:, password:, name:, **_kwargs)
+      user = User.find_for_database_authentication(email: email)
+      return create_user!(email: email, password: password, name: name) if user.blank?
+      return user if user.valid_for_authentication? { user.valid_password?(password) }
+    end
+
+    def create_user!(email:, password:, name:)
+      user = User.new(email: email, name: name, password: password)
+      return unless user.valid?
+
+      user.save!
+      user
+    end
+  end
+end

--- a/app/graphql/types/mutation_type.rb
+++ b/app/graphql/types/mutation_type.rb
@@ -16,6 +16,7 @@ module Types
     field :song_create, mutation: Mutations::SongCreate
 
     field :team_activate, mutation: Mutations::TeamActivate
+    field :team_create, mutation: Mutations::TeamCreate
 
     field :user_library_record_delete, mutation: Mutations::UserLibraryRecordDelete
   end

--- a/spec/mutations/team_create_spec.rb
+++ b/spec/mutations/team_create_spec.rb
@@ -1,0 +1,129 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Invitation Create", type: :request do
+  include AuthHelper
+  include JsonHelper
+
+  def query
+    %(
+      mutation TeamCreate($teamOwner: TeamOwnerInputObject!, $teamName: String!) {
+        teamCreate(input:{
+          teamOwner: $teamOwner,
+          teamName: $teamName
+        }) {
+          accessToken
+          errors
+        }
+      }
+    )
+  end
+
+  describe "success" do
+    it "creates a team for a new user" do
+      variables = {
+        teamOwner: {
+          email: "team-owner@atdot.com",
+          password: "foobar",
+          name: "Trickster"
+        },
+        teamName: "FrogTown"
+      }
+
+      expect do
+        post(
+          "/api/v1/graphql",
+          params: { query: query, variables: variables }
+        )
+      end.to change(User, :count).by(1).and(change(Team, :count).by(1))
+
+      team = Team.find_by(name: "FrogTown")
+      user = User.find_by(email: "team-owner@atdot.com")
+      expect(team.owner).to eq(user)
+      expect(user.valid_password?("foobar")).to eq(true)
+      expect(user.teams).to include(team)
+
+      token = Doorkeeper::AccessToken.find_by(token: json_body.dig(:data, :teamCreate, :accessToken))
+      expect(token.resource_owner_id).to eq(user.id)
+    end
+
+    it "creates a new team for an existing user" do
+      User.create!(email: "team-owner@atdot.com", password: "foobar", teams: [])
+      variables = {
+        teamOwner: {
+          email: "team-owner@atdot.com",
+          password: "foobar",
+          name: "Trickster"
+        },
+        teamName: "FrogTown"
+      }
+
+      expect(Team.exists?(name: "FrogTown ")).to eq(false)
+      expect do
+        post(
+          "/api/v1/graphql",
+          params: { query: query, variables: variables }
+        )
+      end.not_to change(User, :count)
+
+      team = Team.find_by(name: "FrogTown")
+      user = User.find_by(email: "team-owner@atdot.com")
+      expect(team.owner).to eq(user)
+      expect(user.valid_password?("foobar")).to eq(true)
+      expect(user.teams).to include(team)
+
+      token = Doorkeeper::AccessToken.find_by(token: json_body.dig(:data, :teamCreate, :accessToken))
+      expect(token.resource_owner_id).to eq(user.id)
+    end
+  end
+
+  describe "error" do
+    it "does not create a team when user exists and does not auth" do
+      user = User.create!(email: "team-owner@atdot.com", password: "foobar", teams: [])
+
+      variables = {
+        teamOwner: {
+          email: "team-owner@atdot.com",
+          password: "flimflam",
+          name: "Trickster"
+        },
+        teamName: "FrogTown"
+      }
+
+      expect do
+        post(
+          "/api/v1/graphql",
+          params: { query: query, variables: variables }
+        )
+      end.not_to change(User, :count)
+
+      user.reload
+      expect(user.teams).to be_empty
+
+      expect(json_body.dig(:data, :teamCreate, :accessToken)).to be_nil
+      expect(json_body.dig(:data, :teamCreate, :errors)).to include(/Unable to authenticate user/)
+    end
+
+    it "does not allow a user to be created with an insecure password" do
+      variables = {
+        teamOwner: {
+          email: "team-owner@atdot.com",
+          password: "easy",
+          name: "Trickster"
+        },
+        teamName: "FrogTown"
+      }
+
+      expect do
+        post(
+          "/api/v1/graphql",
+          params: { query: query, variables: variables }
+        )
+      end.not_to change(User, :count)
+
+      expect(json_body.dig(:data, :teamCreate, :accessToken)).to be_nil
+      expect(json_body.dig(:data, :teamCreate, :errors)).to include(/Unable to authenticate user/)
+    end
+  end
+end


### PR DESCRIPTION
@go-between/folks 

Adds a "Team Create" mutation to allow a new (or existing) user to create a new team.  Excludes billing for now, but this'll be the place that we hook in to that.