### PR TITLE
Fix 401 errors on accepting invites

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,10 +1,6 @@
 # frozen_string_literal: true
 
 class ApplicationController < ActionController::API
-  # rescue_from Exception do |e|
-  #   # handle_exception(e)
-  # end
-
   before_action :conditional_authorize!
 
   private
@@ -21,6 +17,7 @@ class ApplicationController < ActionController::API
     graphql_query = params[:query].gsub(/\s+/, "")
     return if /^mutation.*\{invitationAccept/ =~ graphql_query
     return if /^mutation.*\{teamCreate/ =~ graphql_query
+    return if /^query.*\{invitation/ =~ graphql_query
 
     doorkeeper_authorize!
   end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,26 +1,7 @@
 # frozen_string_literal: true
 
 class ApplicationController < ActionController::API
-  before_action :conditional_authorize!
-
   private
-
-  def conditional_authorize!
-    return doorkeeper_authorize! unless request.controller_class == GraphqlController
-
-    # Note:  Okay, okay.  Maybe there's a better way to skip authentication
-    #        when we accept an invitation.  But I'd prefer not to push auth
-    #        down in to every query/mutation, and I'd prefer not to support
-    #        a separate api resource just for accepting invitations.
-    # Note:  Yeah but it's the rule of THREES so one more of these and then
-    #        we'll figure out what to do instead of this.
-    graphql_query = params[:query].gsub(/\s+/, "")
-    return if /^mutation.*\{invitationAccept/ =~ graphql_query
-    return if /^mutation.*\{teamCreate/ =~ graphql_query
-    return if /^query.*\{invitation/ =~ graphql_query
-
-    doorkeeper_authorize!
-  end
 
   def current_user
     return @_current_user if defined? @_current_user

--- a/app/controllers/graphql_controller.rb
+++ b/app/controllers/graphql_controller.rb
@@ -11,6 +11,8 @@ class GraphqlController < ApplicationController
 
     result = MusicboxApiSchema.execute(query, variables: variables, context: context, operation_name: operation_name)
     render json: result
+  rescue NotAuthenticatedError
+    render status: 401
   rescue StandardError => e
     raise e unless Rails.env.development?
 

--- a/app/graphql/mutations/base_mutation.rb
+++ b/app/graphql/mutations/base_mutation.rb
@@ -2,6 +2,12 @@
 
 module Mutations
   class BaseMutation < GraphQL::Schema::RelayClassicMutation
+    def ready?(**_args)
+      raise NotAuthenticatedError, "You have to be logged in." if context[:current_user].blank?
+
+      true
+    end
+
     private
 
     def current_user

--- a/app/graphql/mutations/invitation_accept.rb
+++ b/app/graphql/mutations/invitation_accept.rb
@@ -13,6 +13,10 @@ module Mutations
     field :access_token, ID, null: true
     field :errors, [String], null: true
 
+    def ready?(**_args)
+      true
+    end
+
     def resolve(invitation:)
       invite = Invitation.find_by(email: invitation[:email].downcase, token: invitation[:token])
       return { errors: ["Invalid invitation"] } if invite.blank?

--- a/app/graphql/mutations/team_create.rb
+++ b/app/graphql/mutations/team_create.rb
@@ -13,6 +13,10 @@ module Mutations
     field :access_token, ID, null: true
     field :errors, [String], null: true
 
+    def ready?(**_args)
+      true
+    end
+
     def resolve(team_owner:, team_name:)
       # Note:  Presumably we also will accept a billing object
       #        and ensure that it contains a valid payment mechanism

--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -17,6 +17,7 @@ module Types
     end
 
     def invitations
+      confirm_current_user!
       return [] if current_user.active_team_id.blank?
 
       Invitation.where(inviting_user: current_user, team: current_user.active_team)
@@ -27,6 +28,7 @@ module Types
     end
 
     def message(id:)
+      confirm_current_user!
       Message.find(id)
     end
 
@@ -36,6 +38,7 @@ module Types
     end
 
     def messages(from: nil, to: nil) # rubocop:disable Metrics/AbcSize
+      confirm_current_user!
       return [] if current_user.active_room.blank?
 
       t = Message.arel_table
@@ -51,6 +54,7 @@ module Types
     end
 
     def room(id:)
+      confirm_current_user!
       rooms = Room.where(id: id)
       rooms = rooms.where(team: current_user.teams) if current_user.present?
       rooms.first
@@ -60,6 +64,7 @@ module Types
     end
 
     def rooms
+      confirm_current_user!
       Room.where(team: current_user.active_team)
     end
 
@@ -68,6 +73,7 @@ module Types
     end
 
     def room_playlist(room_id:)
+      confirm_current_user!
       RoomPlaylist.new(room_id).generate_playlist
     end
 
@@ -76,6 +82,7 @@ module Types
     end
 
     def room_playlist_for_user(historical:)
+      confirm_current_user!
       records = current_user.room_playlist_records.where(room_id: current_user.active_room_id)
       return records.played.order(played_at: :desc) if historical
 
@@ -87,6 +94,7 @@ module Types
     end
 
     def song(id:)
+      confirm_current_user!
       Song.find(id)
     end
 
@@ -94,6 +102,7 @@ module Types
     end
 
     def songs
+      confirm_current_user!
       current_user.songs
     end
 
@@ -101,6 +110,7 @@ module Types
     end
 
     def user
+      confirm_current_user!
       current_user
     end
 
@@ -108,6 +118,11 @@ module Types
 
     def current_user
       context[:current_user]
+    end
+
+    def confirm_current_user!
+      return if context[:override_current_user]
+      raise NotAuthenticatedError unless current_user
     end
   end
 end

--- a/app/lib/not_authenticated_error.rb
+++ b/app/lib/not_authenticated_error.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+class NotAuthenticatedError < StandardError
+end

--- a/app/workers/broadcast_message_worker.rb
+++ b/app/workers/broadcast_message_worker.rb
@@ -5,7 +5,11 @@ class BroadcastMessageWorker
   sidekiq_options queue: "broadcast_message"
 
   def perform(room_id, message_id)
-    queue = MusicboxApiSchema.execute(query: query, variables: { id: message_id })
+    queue = MusicboxApiSchema.execute(
+      query: query,
+      context: { override_current_user: true },
+      variables: { id: message_id }
+    )
     MessageChannel.broadcast_to(Room.find(room_id), queue.to_h)
   end
 

--- a/app/workers/broadcast_now_playing_worker.rb
+++ b/app/workers/broadcast_now_playing_worker.rb
@@ -5,7 +5,11 @@ class BroadcastNowPlayingWorker
   sidekiq_options queue: "broadcast_now_playing"
 
   def perform(room_id)
-    now_playing = MusicboxApiSchema.execute(query: query, variables: { id: room_id })
+    now_playing = MusicboxApiSchema.execute(
+      query: query,
+      context: { override_current_user: true },
+      variables: { id: room_id }
+    )
 
     NowPlayingChannel.broadcast_to(Room.find(room_id), now_playing.to_h)
   end

--- a/app/workers/broadcast_playlist_worker.rb
+++ b/app/workers/broadcast_playlist_worker.rb
@@ -5,7 +5,11 @@ class BroadcastPlaylistWorker
   sidekiq_options queue: "broadcast_playlist"
 
   def perform(room_id)
-    queue = MusicboxApiSchema.execute(query: query, variables: { roomId: room_id })
+    queue = MusicboxApiSchema.execute(
+      query: query,
+      context: { override_current_user: true },
+      variables: { roomId: room_id }
+    )
     RoomPlaylistChannel.broadcast_to(Room.find(room_id), queue.to_h)
   end
 

--- a/app/workers/broadcast_users_worker.rb
+++ b/app/workers/broadcast_users_worker.rb
@@ -5,7 +5,11 @@ class BroadcastUsersWorker
   sidekiq_options queue: "broadcast_users"
 
   def perform(room_id)
-    queue = MusicboxApiSchema.execute(query: query, variables: { id: room_id })
+    queue = MusicboxApiSchema.execute(
+      query: query,
+      context: { override_current_user: true },
+      variables: { id: room_id }
+    )
     UsersChannel.broadcast_to(Room.find(room_id), queue.to_h)
   end
 

--- a/spec/mutations/invitation_create_spec.rb
+++ b/spec/mutations/invitation_create_spec.rb
@@ -121,6 +121,21 @@ RSpec.describe "Invitation Create", type: :request do
       invitation.reload
       expect(invitation).to be_accepted
     end
+
+    it "is unauthorized if user is not logged in" do
+      post(
+        "/api/v1/graphql",
+        params: {
+          query: query,
+          variables: {
+            email: "an-invited-user@atdot.com",
+            name: "the user"
+          }
+        }
+      )
+
+      expect(response).to be_unauthorized
+    end
   end
 
   describe "error" do

--- a/spec/queries/invitation_spec.rb
+++ b/spec/queries/invitation_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Invitation Query", type: :request do
+  include AuthHelper
+  include JsonHelper
+
+  def query
+    %(
+      query InvitationQuery($email: String!, $token: ID!) {
+        invitation(email: $email, token: $token) {
+          email
+          name
+          invitationState
+          team {
+            name
+          }
+          invitingUser {
+            name
+          }
+        }
+      }
+    )
+  end
+
+  describe "query" do
+    it "returns an invitation if queried" do
+      variables = {
+        email: "jimbo@derp.com",
+        token: SecureRandom.uuid,
+      }
+      post("/api/v1/graphql", params: { query: query, variables: variables })
+
+      expect(response).to be_successful
+    end
+  end
+end

--- a/spec/queries/invitation_spec.rb
+++ b/spec/queries/invitation_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe "Invitation Query", type: :request do
     it "returns an invitation if queried" do
       variables = {
         email: "jimbo@derp.com",
-        token: SecureRandom.uuid,
+        token: SecureRandom.uuid
       }
       post("/api/v1/graphql", params: { query: query, variables: variables })
 

--- a/spec/queries/room_spec.rb
+++ b/spec/queries/room_spec.rb
@@ -45,5 +45,11 @@ RSpec.describe "Room Query", type: :request do
       )
       expect(json_body.dig(:data, :room)).to be_nil
     end
+
+    it "returns unauthorized if a user is not signed in" do
+      post("/api/v1/graphql", params: { query: query(room_id: room.id) })
+
+      expect(response).to be_unauthorized
+    end
   end
 end


### PR DESCRIPTION
(pair: @trumanshuck)

Found out that if we accept an invite, it asplodes. Because GraphQL controller wanted a current user. We followed the pattern of old, and then refactored away the trifecta of yuckiness.

@go-between/folks 