### PR TITLE
Shift broadcast outside of lock, clean up queue management

### DIFF
--- a/app/workers/queue_management_worker.rb
+++ b/app/workers/queue_management_worker.rb
@@ -4,34 +4,32 @@ class QueueManagementWorker
   include Sidekiq::Worker
   sidekiq_options queue: "queue_management"
 
-  def perform(room_id) # rubocop:disable Metrics/AbcSize
+  def perform(room_id)
     room = Room.find(room_id)
-    room.with_lock do
-      return if room.playing_until&.future?
+    return if room.playing_until&.future?
 
-      playlist = RoomPlaylist.new(room_id).generate_playlist
-
-      next_record = playlist.first
-      return idle!(room) if next_record.blank?
-
-      next_record.update!(play_state: "played", played_at: Time.zone.now)
-      playing_until = next_record.song.duration_in_seconds.seconds.from_now
-      room.update!(current_record: next_record, playing_until: playing_until)
-
-      BroadcastNowPlayingWorker.perform_async(room_id)
-      BroadcastPlaylistWorker.perform_async(room_id)
-    end
+    update_room!(room)
+    BroadcastNowPlayingWorker.perform_async(room_id)
+    BroadcastPlaylistWorker.perform_async(room_id)
   end
 
   private
 
+  def update_room!(room)
+    room.with_lock do
+      next_record = RoomPlaylist.new(room.id).generate_playlist.first
+      return idle!(room) if next_record.blank?
+
+      next_record.update!(play_state: "played", played_at: Time.zone.now)
+      room.update!(current_record: next_record, playing_until: playing_until(next_record))
+    end
+  end
+
+  def playing_until(record)
+    record.song.duration_in_seconds.seconds.from_now
+  end
+
   def idle!(room)
-    just_finished = room.current_record.present?
     room.update!(current_record: nil, playing_until: nil, waiting_songs: false)
-
-    return unless just_finished
-
-    BroadcastNowPlayingWorker.perform_async(room.id)
-    BroadcastPlaylistWorker.perform_async(room.id)
   end
 end

--- a/spec/workers/queue_management_worker_spec.rb
+++ b/spec/workers/queue_management_worker_spec.rb
@@ -36,18 +36,6 @@ RSpec.describe QueueManagementWorker, type: :worker do
         expect(BroadcastNowPlayingWorker).to have_enqueued_sidekiq_job(room.id)
       end
     end
-
-    context "when its previous run was empty" do
-      it "does not broadcast to now playing" do
-        worker.perform(room.id)
-        expect(BroadcastNowPlayingWorker).not_to have_enqueued_sidekiq_job(anything)
-      end
-
-      it "does not broadcasts to queue" do
-        worker.perform(room.id)
-        expect(BroadcastPlaylistWorker).not_to have_enqueued_sidekiq_job(anything)
-      end
-    end
   end
 
   context "when queue has songs to play" do


### PR DESCRIPTION
@go-between/folks 

I _think_ this might fix the "song not playing" error (not the weird "click-to-play" on Safari, which we'll have to figure out separately).  I think that including the two `Broadcast` workers within the lock sometimes caused the room itself not to be updated before the workers were executed.  Anyway since this change I haven't been able to reproduce the problem locally, so we'll have to see after this gets deployed.

Also cleans up the logic in `QueueManagementWorker` a bit.  There's a slight behavior change in that we no longer care if this worker has run just after an "empty" run.  This was quite common when we were re-queuing this job over and over again to manage the queue, but should not really be common with the new event polling thing that we do.