### PR TITLE
Include future check in room lock

### DIFF
--- a/app/workers/queue_management_worker.rb
+++ b/app/workers/queue_management_worker.rb
@@ -6,22 +6,26 @@ class QueueManagementWorker
 
   def perform(room_id)
     room = Room.find(room_id)
-    return if room.playing_until&.future?
 
-    update_room!(room)
-    BroadcastNowPlayingWorker.perform_async(room_id)
-    BroadcastPlaylistWorker.perform_async(room_id)
+    update_room!(room) do
+      BroadcastNowPlayingWorker.perform_async(room_id)
+      BroadcastPlaylistWorker.perform_async(room_id)
+    end
   end
 
   private
 
   def update_room!(room)
     room.with_lock do
+      return if room.playing_until&.future?
+
       next_record = RoomPlaylist.new(room.id).generate_playlist.first
-      return idle!(room) if next_record.blank?
+      return idle!(room) && yield if next_record.blank?
 
       next_record.update!(play_state: "played", played_at: Time.zone.now)
       room.update!(current_record: next_record, playing_until: playing_until(next_record))
+
+      yield
     end
   end
 


### PR DESCRIPTION
@go-between/folks 

I'm not yet in love with this `yield` pattern but I believe that this guard `return if room.playing_until&.future?` needs to be inside the lock we establish on the room.  The sad case is that the [room poller](https://github.com/go-between/musicbox-api/blob/master/app/lib/poll_room_queue.rb) enqueues a job for the same room twice in a row (because the first job has not yet been processed because the queue is backed up, so it gets selected twice).  Then the first and second job start executing close together so that the `playing_until` has not yet been set.  The first job then acquires a lock on the room and does some work, the second job waits (but the `playing_until` guard has already been passed), and picks up the lock when the first job is done.  It does not realize that it's not yet time for a new song and skips what the first job had just started playing.  Whoops!