### PR TITLE
Maybe really play songs really

### DIFF
--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -74,7 +74,8 @@ module Types
 
     def room_playlist(room_id:)
       confirm_current_user!
-      RoomPlaylist.new(room_id).generate_playlist
+      room = Room.find(room_id)
+      RoomPlaylist.new(room).generate_playlist
     end
 
     field :room_playlist_for_user, [Types::RoomPlaylistRecordType], null: true do

--- a/app/lib/room_playlist.rb
+++ b/app/lib/room_playlist.rb
@@ -1,17 +1,17 @@
 # frozen_string_literal: true
 
 class RoomPlaylist
-  attr_reader :room_id
+  attr_reader :room
 
-  def initialize(room_id)
-    @room_id = room_id
+  def initialize(room)
+    @room = room
   end
 
   def generate_playlist
     return [] if user_rotation.blank?
 
     ordered_waiting_songs = []
-    waiting_songs = RoomPlaylistRecord.where(room_id: room_id, play_state: "waiting").to_a
+    waiting_songs = RoomPlaylistRecord.where(room_id: room.id, play_state: "waiting").to_a
 
     waiting_user_rotation.each_with_index do |user_id, idx|
       waiting_songs_for_user(waiting_songs, user_id).each_with_index do |song, song_idx|
@@ -43,12 +43,6 @@ class RoomPlaylist
 
   def current_record_user_id
     room.current_record&.user_id
-  end
-
-  def room
-    return @room if defined? @room
-
-    @room ||= Room.find(room_id)
   end
 
   def user_rotation

--- a/app/lib/room_playlist.rb
+++ b/app/lib/room_playlist.rb
@@ -1,20 +1,19 @@
 # frozen_string_literal: true
 
 class RoomPlaylist
-  attr_reader :room
+  attr_reader :room, :waiting_songs
 
   def initialize(room)
     @room = room
+    @waiting_songs = RoomPlaylistRecord.where(room_id: room.id, play_state: "waiting").to_a
   end
 
   def generate_playlist
     return [] if user_rotation.blank?
 
     ordered_waiting_songs = []
-    waiting_songs = RoomPlaylistRecord.where(room_id: room.id, play_state: "waiting").to_a
-
     waiting_user_rotation.each_with_index do |user_id, idx|
-      waiting_songs_for_user(waiting_songs, user_id).each_with_index do |song, song_idx|
+      waiting_songs_for_user(user_id).each_with_index do |song, song_idx|
         ordered_waiting_songs[idx + (waiting_user_rotation.size * song_idx)] = song
       end
     end
@@ -24,7 +23,7 @@ class RoomPlaylist
 
   private
 
-  def waiting_songs_for_user(waiting_songs, user_id)
+  def waiting_songs_for_user(user_id)
     waiting_songs.select { |song| song.user_id == user_id }.sort_by(&:order)
   end
 

--- a/app/lib/room_playlist.rb
+++ b/app/lib/room_playlist.rb
@@ -11,11 +11,10 @@ class RoomPlaylist
     return [] if user_rotation.blank?
 
     ordered_waiting_songs = []
-    waiting_songs = RoomPlaylistRecord.where(room_id: room_id, play_state: "waiting")
+    waiting_songs = RoomPlaylistRecord.where(room_id: room_id, play_state: "waiting").to_a
 
     waiting_user_rotation.each_with_index do |user_id, idx|
-      user_waiting_songs = waiting_songs.where(user_id: user_id).order(:order)
-      user_waiting_songs.each_with_index do |song, song_idx|
+      waiting_songs_for_user(waiting_songs, user_id).each_with_index do |song, song_idx|
         ordered_waiting_songs[idx + (waiting_user_rotation.size * song_idx)] = song
       end
     end
@@ -24,6 +23,10 @@ class RoomPlaylist
   end
 
   private
+
+  def waiting_songs_for_user(waiting_songs, user_id)
+    waiting_songs.select { |song| song.user_id == user_id }.sort_by(&:order)
+  end
 
   def waiting_user_rotation
     next_user_index = user_rotation.find_index(next_user)

--- a/app/models/room.rb
+++ b/app/models/room.rb
@@ -9,4 +9,8 @@ class Room < ApplicationRecord
   belongs_to :current_record, foreign_key: :current_record_id, class_name: "RoomPlaylistRecord", optional: true
   has_one :current_song, through: :current_record, source: :song
   belongs_to :team
+
+  def idle!
+    update!(current_record: nil, playing_until: nil, waiting_songs: false)
+  end
 end

--- a/app/models/room.rb
+++ b/app/models/room.rb
@@ -11,6 +11,25 @@ class Room < ApplicationRecord
   belongs_to :team
 
   def idle!
-    update!(current_record: nil, playing_until: nil, waiting_songs: false)
+    update!(
+      current_record: nil,
+      playing_until: nil,
+      queue_processing: false,
+      waiting_songs: false
+    )
+  end
+
+  def playing_record!(record)
+    update!(
+      current_record: record,
+      playing_until: playing_until_datetime(record),
+      queue_processing: false
+    )
+  end
+
+  private
+
+  def playing_until_datetime(record)
+    record.song.duration_in_seconds.seconds.from_now
   end
 end

--- a/db/migrate/20200223055015_add_queue_processing_to_room.rb
+++ b/db/migrate/20200223055015_add_queue_processing_to_room.rb
@@ -1,0 +1,5 @@
+class AddQueueProcessingToRoom < ActiveRecord::Migration[6.0]
+  def change
+    add_column :rooms, :queue_processing, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_02_09_060935) do
+ActiveRecord::Schema.define(version: 2020_02_23_055015) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -102,6 +102,7 @@ ActiveRecord::Schema.define(version: 2020_02_09_060935) do
     t.uuid "team_id"
     t.datetime "playing_until"
     t.boolean "waiting_songs"
+    t.boolean "queue_processing", default: false
     t.index ["playing_until"], name: "index_rooms_on_playing_until"
   end
 

--- a/spec/lib/poll_room_queue_spec.rb
+++ b/spec/lib/poll_room_queue_spec.rb
@@ -9,6 +9,8 @@ RSpec.describe PollRoomQueue do
       not_done = create(:room, playing_until: 1.minute.from_now)
       # No songs waiting to be played
       none_waiting = create(:room, playing_until: nil, waiting_songs: false)
+      # has song, but is already processing
+      already_processing = create(:room, playing_until: 1.minute.ago, queue_processing: true, waiting_songs: true)
 
       recently_finished1 = create(:room, playing_until: 1.second.ago)
       recently_finished2 = create(:room, playing_until: 1.minute.ago)
@@ -20,6 +22,7 @@ RSpec.describe PollRoomQueue do
 
       expect(QueueManagementWorker).not_to have_enqueued_sidekiq_job(not_done.id)
       expect(QueueManagementWorker).not_to have_enqueued_sidekiq_job(none_waiting.id)
+      expect(QueueManagementWorker).not_to have_enqueued_sidekiq_job(already_processing.id)
       expect(QueueManagementWorker).to have_enqueued_sidekiq_job(recently_finished1.id)
       expect(QueueManagementWorker).to have_enqueued_sidekiq_job(recently_finished2.id)
       expect(QueueManagementWorker).to have_enqueued_sidekiq_job(with_waiting_song1.id)

--- a/spec/lib/room_playlist_spec.rb
+++ b/spec/lib/room_playlist_spec.rb
@@ -19,14 +19,14 @@ RSpec.describe RoomPlaylist do
       record5 = create(:room_playlist_record, room: room, user: user_2, order: 2, play_state: "waiting")
       record6 = create(:room_playlist_record, room: room, user: user_3, order: 20, play_state: "waiting")
 
-      playlist = described_class.new(room.id)
+      playlist = described_class.new(room)
 
       expect(playlist.generate_playlist).to eq([record3, record4, record5, record6])
     end
 
     it "returns an empty queue when no users are in rotation" do
       room.update!(user_rotation: [])
-      playlist = described_class.new(room.id)
+      playlist = described_class.new(room)
 
       expect(playlist.generate_playlist).to be_empty
     end


### PR DESCRIPTION
@go-between/folks 

Tries to clean up a bit more:
  - Casts waiting songs in room playlist class to an array to drop a few db queries
  - Adds a `queue_processing` flag to a room that gets set when the poller runs so that we don't accidentally enqueue a bunch of processing jobs for the same room in case sidekiq is running behind
  - Shifts `idle` and `playing_record` updates into room model (thanks @sisk!)
  - Finally actually shifts `Broadcast` workers outside of the database transaction in the queue management worker.  Because duh if you yield inside of a database transaction, the code run in the yield-ed block is also still in the transaction.