### PR TITLE
Presence

### DIFF
--- a/app/channels/application_cable/channel.rb
+++ b/app/channels/application_cable/channel.rb
@@ -3,9 +3,20 @@
 module ApplicationCable
   class Channel < ActionCable::Channel::Base
     def subscribe_for_current_user
-      return reject if current_user.active_room.blank?
+      return reject if cached_current_user.active_room.blank?
 
-      stream_for current_user.active_room
+      stream_for cached_current_user.active_room
+    end
+
+    private
+
+    def cached_current_user
+      return @cached_current_user if defined? @cached_current_user
+
+      prospective_current_user = current_user
+      return if prospective_current_user.blank?
+
+      @cached_current_user = prospective_current_user
     end
   end
 end

--- a/app/channels/users_channel.rb
+++ b/app/channels/users_channel.rb
@@ -2,4 +2,20 @@
 
 class UsersChannel < ApplicationCable::Channel
   delegate :subscribed, to: :subscribe_for_current_user
+
+  def unsubscribed
+    return if cached_current_user.blank?
+
+    remove_from_room!
+  end
+
+  private
+
+  def remove_from_room!
+    return if cached_current_user.active_room_id.blank?
+
+    previous_room = cached_current_user.active_room_id
+    cached_current_user.update!(active_room: nil)
+    BroadcastUsersWorker.perform_async(previous_room)
+  end
 end

--- a/app/workers/queue_management_worker.rb
+++ b/app/workers/queue_management_worker.rb
@@ -5,7 +5,8 @@ class QueueManagementWorker
   sidekiq_options queue: "queue_management"
 
   def perform(room_id)
-    return unless update_room!(room_id)
+    room = Room.find(room_id)
+    return unless update_room!(room)
 
     BroadcastNowPlayingWorker.perform_async(room_id)
     BroadcastPlaylistWorker.perform_async(room_id)
@@ -13,8 +14,7 @@ class QueueManagementWorker
 
   private
 
-  def update_room!(room_id)
-    room = Room.find(room_id)
+  def update_room!(room)
     room.with_lock do
       return unless room.queue_processing?
       return if room.playing_until&.future?
@@ -27,6 +27,7 @@ class QueueManagementWorker
 
       next_record.update!(play_state: "played", played_at: Time.zone.now)
       room.playing_record!(next_record)
+      remove_stale_user_from_room!(room, next_record.user.id)
 
       return true
     end
@@ -34,5 +35,13 @@ class QueueManagementWorker
 
   def next_record_in_playlist(room)
     RoomPlaylist.new(room).generate_playlist.first
+  end
+
+  def remove_stale_user_from_room!(room, user_id)
+    user = User.find(user_id)
+    return if user.active_room_id == room.id
+    return if RoomPlaylistRecord.waiting.where(user_id: user.id).exists?
+
+    room.update!(user_rotation: room.user_rotation.without(user_id))
   end
 end

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,6 +24,9 @@ services:
     ports: ["6379:6379"]
   app-poll-room-queue:
     <<: *app-common
+    environment:
+      <<: *app-environment
+      LOG_LEVEL: info
     command: bin/wait-for-it.sh db:5432 -- bin/wait-for-it.sh redis:6379 -- rake room:poll_queue
     ports: []
   app-sidekiq-workers:


### PR DESCRIPTION
@go-between/folks 

The main gist is that we'll respond to `unsubscribed` events on the users channel and remove a user from the active room if the websocket connection goes dead (refresh page, close browser, back out of the application entirely).  We'll also remove them from the room's `user_rotation` only _after_ their last song has been played.

We also silence the incessant query output of the room poller in development so that logs are actually useable, and save ourselves a few queries when setting up websocket subscriptions by caching the current user for the lifetime of the request.