### PR TITLE
Memoize current user where it's actually set in action cable connection

### DIFF
--- a/app/channels/application_cable/channel.rb
+++ b/app/channels/application_cable/channel.rb
@@ -3,20 +3,9 @@
 module ApplicationCable
   class Channel < ActionCable::Channel::Base
     def subscribe_for_current_user
-      return reject if cached_current_user.active_room.blank?
+      return reject if current_user.active_room.blank?
 
-      stream_for cached_current_user.active_room
-    end
-
-    private
-
-    def cached_current_user
-      return @cached_current_user if defined? @cached_current_user
-
-      prospective_current_user = current_user
-      return if prospective_current_user.blank?
-
-      @cached_current_user = prospective_current_user
+      stream_for current_user.active_room
     end
   end
 end

--- a/app/channels/application_cable/connection.rb
+++ b/app/channels/application_cable/connection.rb
@@ -11,8 +11,12 @@ module ApplicationCable
     protected
 
     def current_user
+      return @current_user if defined? @current_user
+
       user = User.find_by(id: access_token.try(:resource_owner_id))
-      user || reject_unauthorized_connection
+      return reject_unauthorized_connection if user.blank?
+
+      @current_user = user
     end
 
     def access_token

--- a/app/channels/users_channel.rb
+++ b/app/channels/users_channel.rb
@@ -4,7 +4,7 @@ class UsersChannel < ApplicationCable::Channel
   delegate :subscribed, to: :subscribe_for_current_user
 
   def unsubscribed
-    return if cached_current_user.blank?
+    return if current_user.blank?
 
     remove_from_room!
   end
@@ -12,10 +12,10 @@ class UsersChannel < ApplicationCable::Channel
   private
 
   def remove_from_room!
-    return if cached_current_user.active_room_id.blank?
+    return if current_user.active_room_id.blank?
 
-    previous_room = cached_current_user.active_room_id
-    cached_current_user.update!(active_room: nil)
+    previous_room = current_user.active_room_id
+    current_user.update!(active_room: nil)
     BroadcastUsersWorker.perform_async(previous_room)
   end
 end


### PR DESCRIPTION
@go-between/folks 

It occurred to me a little after #76 that we're probably actually setting `current_user` somewhere, so maybe we should cache it there instead.  Duh @ me.