### PR TITLE
No delegation bad delegation

### DIFF
--- a/app/channels/application_cable/channel.rb
+++ b/app/channels/application_cable/channel.rb
@@ -2,7 +2,7 @@
 
 module ApplicationCable
   class Channel < ActionCable::Channel::Base
-    def subscribe_for_current_user
+    def subscribed
       return reject if current_user.active_room.blank?
 
       stream_for current_user.active_room

--- a/app/channels/application_cable/connection.rb
+++ b/app/channels/application_cable/connection.rb
@@ -5,18 +5,14 @@ module ApplicationCable
     identified_by :current_user
 
     def connect
-      self.current_user = current_user
+      current_user
     end
 
     protected
 
     def current_user
-      return @current_user if defined? @current_user
-
       user = User.find_by(id: access_token.try(:resource_owner_id))
-      return reject_unauthorized_connection if user.blank?
-
-      @current_user = user
+      user || reject_unauthorized_connection
     end
 
     def access_token

--- a/app/channels/message_channel.rb
+++ b/app/channels/message_channel.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
 
 class MessageChannel < ApplicationCable::Channel
-  delegate :subscribed, to: :subscribe_for_current_user
 end

--- a/app/channels/now_playing_channel.rb
+++ b/app/channels/now_playing_channel.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
 
 class NowPlayingChannel < ApplicationCable::Channel
-  delegate :subscribed, to: :subscribe_for_current_user
 end

--- a/app/channels/room_playlist_channel.rb
+++ b/app/channels/room_playlist_channel.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
 
 class RoomPlaylistChannel < ApplicationCable::Channel
-  delegate :subscribed, to: :subscribe_for_current_user
 end

--- a/app/channels/users_channel.rb
+++ b/app/channels/users_channel.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 class UsersChannel < ApplicationCable::Channel
-  delegate :subscribed, to: :subscribe_for_current_user
-
   def unsubscribed
     return if current_user.blank?
 

--- a/app/workers/queue_management_worker.rb
+++ b/app/workers/queue_management_worker.rb
@@ -19,9 +19,9 @@ class QueueManagementWorker
       return unless room.queue_processing?
       return if room.playing_until&.future?
 
+      next_record = next_record_in_playlist(room)
       remove_stale_user_from_room!(room)
 
-      next_record = next_record_in_playlist(room)
       if next_record.blank?
         room.idle!
         return true


### PR DESCRIPTION
@go-between/folks 

Delegating within a channel apparently causes a bunch of insane things to happen, which maybe silently half-broke websockets for a while.  We'll also lock around the room when generating a playlist to avoid weird bugs if a user leaves while the queue management worker is running.

Finally, we wait until a user's last song has been played and the next song chosen before removing them from the user rotation rather than after their last song has started playing -- so that we always know what song to play next.