### PR TITLE
Tags

### DIFF
--- a/app/graphql/mutations/tag_associate.rb
+++ b/app/graphql/mutations/tag_associate.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+module Mutations
+  class TagAssociate < Mutations::BaseMutation
+    argument :tag_id, ID, required: true
+    argument :song_id, ID, required: true
+
+    field :tag, Types::TagType, null: true
+    field :errors, [String], null: true
+
+    def resolve(tag_id:, song_id:)
+      tag = current_user.tags.find_by(id: tag_id)
+      song = current_user.songs.find_by(id: song_id)
+
+      unless tag.present? && song.present?
+        return {
+          tag: nil,
+          errors: ["Tag and Song must be present"]
+        }
+      end
+
+      tag.songs << song unless tag.songs.exists?(song.id)
+
+      {
+        tag: tag,
+        errors: []
+      }
+    end
+  end
+end

--- a/app/graphql/mutations/tag_create.rb
+++ b/app/graphql/mutations/tag_create.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+module Mutations
+  class TagCreate < Mutations::BaseMutation
+    argument :name, String, required: true
+
+    field :tag, Types::TagType, null: true
+    field :errors, [String], null: true
+
+    def resolve(name:)
+      tag = Tag.new(
+        name: name,
+        user: current_user
+      )
+
+      unless tag.valid?
+        return {
+          tag: nil,
+          errors: tag.errors.full_messages
+        }
+      end
+
+      tag.save!
+
+      {
+        tag: tag,
+        errors: []
+      }
+    end
+  end
+end

--- a/app/graphql/types/mutation_type.rb
+++ b/app/graphql/types/mutation_type.rb
@@ -15,6 +15,7 @@ module Types
 
     field :song_create, mutation: Mutations::SongCreate
 
+    field :tag_associate, mutation: Mutations::TagAssociate
     field :tag_create, mutation: Mutations::TagCreate
 
     field :team_activate, mutation: Mutations::TeamActivate

--- a/app/graphql/types/mutation_type.rb
+++ b/app/graphql/types/mutation_type.rb
@@ -15,6 +15,8 @@ module Types
 
     field :song_create, mutation: Mutations::SongCreate
 
+    field :tag_create, mutation: Mutations::TagCreate
+
     field :team_activate, mutation: Mutations::TeamActivate
     field :team_create, mutation: Mutations::TeamCreate
 

--- a/app/graphql/types/song_type.rb
+++ b/app/graphql/types/song_type.rb
@@ -9,5 +9,6 @@ module Types
     field :duration_in_seconds, Int, null: true
     field :name, String, null: true
     field :youtube_id, ID, null: false
+    field :tags, [Types::TagType], null: false
   end
 end

--- a/app/graphql/types/tag_type.rb
+++ b/app/graphql/types/tag_type.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module Types
+  class TagType < Types::BaseObject
+    graphql_name "Tag"
+
+    field :id, ID, null: false
+    field :name, String, null: false
+    field :user, Types::UserType, null: false
+    field :songs, [Types::SongType], null: false
+  end
+end

--- a/app/models/song.rb
+++ b/app/models/song.rb
@@ -4,4 +4,6 @@ class Song < ApplicationRecord
   validates :youtube_id, presence: true
   has_many :user_library_records
   has_many :users, through: :user_library_records
+  has_many :tag_songs
+  has_many :tags, through: :tag_songs
 end

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+class Tag < ApplicationRecord
+  belongs_to :user
+end

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -2,4 +2,6 @@
 
 class Tag < ApplicationRecord
   belongs_to :user
+  has_many :tag_songs
+  has_many :songs, through: :tag_songs
 end

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class Tag < ApplicationRecord
+  validates :name, presence: true
+
   belongs_to :user
   has_many :tag_songs
   has_many :songs, through: :tag_songs

--- a/app/models/tag_song.rb
+++ b/app/models/tag_song.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class TagSong < ApplicationRecord
+  self.table_name = "tags_songs"
+  belongs_to :tag
+  belongs_to :song
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -12,6 +12,7 @@ class User < ApplicationRecord
   has_many :room_playlist_records
   has_many :user_library_records
   has_many :songs, through: :user_library_records
+  has_many :tags
   has_many :team_users
   has_many :teams, through: :team_users
 end

--- a/db/migrate/20200304014052_create_tags_table.rb
+++ b/db/migrate/20200304014052_create_tags_table.rb
@@ -1,0 +1,11 @@
+class CreateTagsTable < ActiveRecord::Migration[6.0]
+  def change
+    create_table :tags, id: :uuid do |t|
+      t.uuid :user_id
+      t.string :name
+
+      t.timestamps
+      t.index :user_id
+    end
+  end
+end

--- a/db/migrate/20200304014747_create_tags_songs.rb
+++ b/db/migrate/20200304014747_create_tags_songs.rb
@@ -1,0 +1,12 @@
+class CreateTagsSongs < ActiveRecord::Migration[6.0]
+  def change
+    create_table :tags_songs, id: :uuid do |t|
+      t.uuid :tag_id
+      t.uuid :song_id
+
+      t.timestamps
+      t.index :tag_id
+      t.index :song_id
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_02_26_234654) do
+ActiveRecord::Schema.define(version: 2020_03_04_014052) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_trgm"
@@ -116,6 +116,14 @@ ActiveRecord::Schema.define(version: 2020_02_26_234654) do
     t.string "description"
     t.index ["name"], name: "index_songs_on_name", opclass: :gin_trgm_ops, using: :gin
     t.index ["youtube_id"], name: "index_songs_on_youtube_id"
+  end
+
+  create_table "tags", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.uuid "user_id"
+    t.string "name"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["user_id"], name: "index_tags_on_user_id"
   end
 
   create_table "teams", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_03_04_014052) do
+ActiveRecord::Schema.define(version: 2020_03_04_014747) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_trgm"
@@ -124,6 +124,15 @@ ActiveRecord::Schema.define(version: 2020_03_04_014052) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.index ["user_id"], name: "index_tags_on_user_id"
+  end
+
+  create_table "tags_songs", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.uuid "tag_id"
+    t.uuid "song_id"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["song_id"], name: "index_tags_songs_on_song_id"
+    t.index ["tag_id"], name: "index_tags_songs_on_tag_id"
   end
 
   create_table "teams", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|

--- a/spec/factories/tag.rb
+++ b/spec/factories/tag.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :tag do
+    name { "jam city" }
+    user
+  end
+end

--- a/spec/models/song_spec.rb
+++ b/spec/models/song_spec.rb
@@ -23,5 +23,16 @@ RSpec.describe Song, type: :model do
 
       expect(song.reload.users).to match_array([user1, user2, user2])
     end
+
+    it "has many tags" do
+      user = create(:user)
+      tag1 = create(:tag, user: user)
+      tag2 = create(:tag, user: user)
+
+      song.tags << tag1
+      song.tags << tag2
+
+      expect(song.tags).to match_array([tag1, tag2])
+    end
   end
 end

--- a/spec/models/tag_spec.rb
+++ b/spec/models/tag_spec.rb
@@ -5,6 +5,7 @@ require "rails_helper"
 RSpec.describe Tag, type: :model do
   describe "relationships" do
     let(:user) { create(:user) }
+
     it "belongs to a user" do
       tag = described_class.create!(name: "the-tag", user: user)
 

--- a/spec/models/tag_spec.rb
+++ b/spec/models/tag_spec.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Tag, type: :model do
+  describe "relationships" do
+    it "belongs to a user" do
+      user = create(:user)
+      tag = described_class.create!(name: "the-tag", user: user)
+
+      expect(tag.user).to eq(user)
+    end
+  end
+end

--- a/spec/models/tag_spec.rb
+++ b/spec/models/tag_spec.rb
@@ -4,11 +4,23 @@ require "rails_helper"
 
 RSpec.describe Tag, type: :model do
   describe "relationships" do
+    let(:user) { create(:user) }
     it "belongs to a user" do
-      user = create(:user)
       tag = described_class.create!(name: "the-tag", user: user)
 
       expect(tag.user).to eq(user)
+    end
+
+    it "has many songs" do
+      tag = described_class.create!(name: "the-tag", user: user)
+
+      song1 = create(:song)
+      song2 = create(:song)
+
+      tag.songs << song1
+      tag.songs << song2
+
+      expect(tag.songs).to match_array([song1, song2])
     end
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -25,6 +25,14 @@ RSpec.describe User, type: :model do
       expect(user.reload.songs).to match_array([song1, song2, song2])
     end
 
+    it "has many tags" do
+      t1 = create(:tag, user: user)
+      t2 = create(:tag, user: user)
+      t3 = create(:tag, user: user)
+
+      expect(user.tags).to match_array([t1, t2, t3])
+    end
+
     it "may belong to one active room" do
       room = create(:room)
       user.update!(active_room: room)

--- a/spec/mutations/tag_associate_spec.rb
+++ b/spec/mutations/tag_associate_spec.rb
@@ -1,0 +1,127 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Tag Create", type: :request do
+  include AuthHelper
+  include JsonHelper
+
+  def query
+    %(
+      mutation TagAssociate($tagId: ID!, $songId: ID!) {
+        tagAssociate(input:{
+          tagId: $tagId,
+          songId: $songId
+        }) {
+          tag {
+            id
+            name
+            user {
+              id
+            }
+            songs {
+              id
+            }
+          }
+          errors
+        }
+      }
+    )
+  end
+
+  let(:current_user) { create(:user, active_team: create(:team)) }
+  let(:tag) { create(:tag, user: current_user) }
+  let(:song) { create(:song, users: [current_user]) }
+
+  describe "adding an association" do
+    it "associates the song to the tag" do
+      expect do
+        graphql_request(
+          query: query,
+          variables: { tagId: tag.id, songId: song.id },
+          user: current_user
+        )
+      end.to change(TagSong, :count).by(1)
+
+      data = json_body.dig(:data, :tagAssociate, :tag, :songs)
+      song_ids = data.map { |song| song[:id] }
+
+      expect(song_ids).to match_array(song_ids)
+    end
+
+    it "noops when a song is already associated to a tag" do
+      TagSong.create!(tag: tag, song: song)
+
+      expect do
+        graphql_request(
+          query: query,
+          variables: { tagId: tag.id, songId: song.id },
+          user: current_user
+        )
+      end.not_to change(TagSong, :count)
+
+      data = json_body.dig(:data, :tagAssociate, :tag, :songs)
+      song_ids = data.map { |song| song[:id] }
+
+      expect(song_ids).to match_array(song_ids)
+    end
+  end
+
+  context "when tag is misconfigured" do
+    it "returns an error when tag does not exist" do
+      expect do
+        graphql_request(
+          query: query,
+          variables: { tagId: SecureRandom.uuid, songId: song.id },
+          user: current_user
+        )
+      end.not_to change(TagSong, :count)
+
+      expect(json_body.dig(:data, :tagAssociate, :tag)).to be_nil
+      expect(json_body.dig(:data, :tagAssociate, :errors)).to include("Tag and Song must be present")
+    end
+
+    it "returns an error when tag is not associated with the user" do
+      other_tag = create(:tag, user: create(:user))
+      expect do
+        graphql_request(
+          query: query,
+          variables: { tagId: other_tag.id, songId: song.id },
+          user: current_user
+        )
+      end.not_to change(TagSong, :count)
+
+      expect(json_body.dig(:data, :tagAssociate, :tag)).to be_nil
+      expect(json_body.dig(:data, :tagAssociate, :errors)).to include("Tag and Song must be present")
+    end
+  end
+
+  context "when song is misconfigured" do
+    it "returns an error when song does not exist" do
+      expect do
+        graphql_request(
+          query: query,
+          variables: { tagId: tag.id, songId: SecureRandom.uuid },
+          user: current_user
+        )
+      end.not_to change(TagSong, :count)
+
+      expect(json_body.dig(:data, :tagAssociate, :tag)).to be_nil
+      expect(json_body.dig(:data, :tagAssociate, :errors)).to include("Tag and Song must be present")
+    end
+
+    it "returns an error when song is not associated with the user" do
+      other_song = create(:song, users: [create(:user)])
+      expect do
+        graphql_request(
+          query: query,
+          variables: { tagId: tag.id, songId: other_song.id },
+          user: current_user
+        )
+      end.not_to change(TagSong, :count)
+
+      expect(json_body.dig(:data, :tagAssociate, :tag)).to be_nil
+      expect(json_body.dig(:data, :tagAssociate, :errors)).to include("Tag and Song must be present")
+    end
+  end
+end

--- a/spec/mutations/tag_create_spec.rb
+++ b/spec/mutations/tag_create_spec.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Tag Create", type: :request do
+  include AuthHelper
+  include JsonHelper
+
+  def query
+    %(
+      mutation TagCreate($name: String!) {
+        tagCreate(input:{
+          name: $name
+        }) {
+          tag {
+            id
+            name
+            user {
+              id
+            }
+            songs {
+              id
+            }
+          }
+          errors
+        }
+      }
+    )
+  end
+
+  let(:current_user) { create(:user, active_team: create(:team)) }
+
+  describe "#create" do
+    it "creates a tag" do
+      graphql_request(
+        query: query,
+        variables: { name: "Jam City" },
+        user: current_user
+      )
+      data = json_body.dig(:data, :tagCreate, :tag)
+
+      expect(Tag.exists?(id: data[:id])).to eq(true)
+      expect(data[:name]).to eq("Jam City")
+      expect(data.dig(:user, :id)).to eq(current_user.id)
+      expect(data[:songs]).to be_empty
+    end
+  end
+
+  context "when missing required attributes" do
+    it "fails to persist when name is not specified" do
+      expect do
+        graphql_request(
+          query: query,
+          variables: { name: "" },
+          user: current_user
+        )
+      end.not_to change(Tag, :count)
+
+      data = json_body.dig(:data, :tagCreate)
+
+      expect(data[:tag]).to be_nil
+      expect(data[:errors]).to match_array([include("Name can't be blank")])
+    end
+  end
+end

--- a/spec/queries/songs_spec.rb
+++ b/spec/queries/songs_spec.rb
@@ -8,8 +8,8 @@ RSpec.describe "Songs Query", type: :request do
 
   def query
     %(
-      query Songs($query: String) {
-        songs(query: $query) {
+      query Songs($query: String, $tagIds: [ID!]) {
+        songs(query: $query, tagIds: $tagIds) {
           id
         }
       }
@@ -51,16 +51,13 @@ RSpec.describe "Songs Query", type: :request do
     end
   end
 
-  it "retrieves only matching songs" do
+  it "retrieves only matching songs by name" do
     non_match = create(:song, name: "ballooba")
     s1 = create(:song, name: "floopadoop")
     s2 = create(:song, name: "LOOPABLARG")
     s3 = create(:song, name: "bling!!!LoOp")
 
-    user.songs << non_match
-    user.songs << s1
-    user.songs << s2
-    user.songs << s3
+    user.update!(songs: [non_match, s1, s2, s3])
 
     %w[LOOP loop LoOp].each do |term|
       graphql_request(query: query, user: user, variables: { query: term })
@@ -68,5 +65,44 @@ RSpec.describe "Songs Query", type: :request do
       song_ids = json_body.dig(:data, :songs).map { |s| s[:id] }
       expect(song_ids).to match_array([s1.id, s2.id, s3.id])
     end
+  end
+
+  it "retrives only matching songs by tag ids" do
+    tag1 = create(:tag, user: user)
+    tag2 = create(:tag, user: user)
+
+    s1 = create(:song, tags: [tag1])
+    s2 = create(:song, tags: [tag2])
+    s3 = create(:song, tags: [tag1, tag2])
+    create(:song, tags: [])
+
+    user.update!(songs: [s1, s2, s3])
+
+    graphql_request(query: query, user: user, variables: { tagIds: [tag1.id] })
+    song_ids = json_body.dig(:data, :songs).map { |s| s[:id] }
+    expect(song_ids).to match_array([s1.id, s3.id])
+
+    graphql_request(query: query, user: user, variables: { tagIds: [tag2.id] })
+    song_ids = json_body.dig(:data, :songs).map { |s| s[:id] }
+    expect(song_ids).to match_array([s2.id, s3.id])
+
+    graphql_request(query: query, user: user, variables: { tagIds: [tag1.id, tag2.id] })
+    song_ids = json_body.dig(:data, :songs).map { |s| s[:id] }
+    expect(song_ids).to match_array([s1.id, s2.id, s3.id])
+  end
+
+  it "retrieves only matching songs by name and tag" do
+    tag1 = create(:tag, user: user)
+    tag2 = create(:tag, user: user)
+
+    s1 = create(:song, name: "blingblong", tags: [tag1])
+    s2 = create(:song, name: "blingflong", tags: [tag2])
+    s3 = create(:song, name: "blooperdoooper", tags: [tag2])
+
+    user.update!(songs: [s1, s2, s3])
+
+    graphql_request(query: query, user: user, variables: { query: "ing", tagIds: [tag2.id] })
+    song_ids = json_body.dig(:data, :songs).map { |s| s[:id] }
+    expect(song_ids).to match_array([s2.id])
   end
 end


### PR DESCRIPTION
@go-between/folks 

This PR adds support for tagging songs with arbitrary tags by a user, as well as querying a user's songs by those tags.  We use an almost-normalized schema where the tags themselves may be duplicated between users even if they're represented by the same string.  A user has many tags, which in turn have many songs (through a `tags_songs` join table).

My brain quit working during the `songs` query, so we're doing the tag-filtering in the slowest way possible.  Would love some more thoughts about how to shove that all into sql via arel or active record.

