### PR TITLE
Allow skylight to better trace graphql

### DIFF
--- a/app/workers/broadcast_message_worker.rb
+++ b/app/workers/broadcast_message_worker.rb
@@ -17,7 +17,7 @@ class BroadcastMessageWorker
 
   def query # rubocop:disable Metrics/MethodLength
     %(
-      query($id: ID!) {
+      query BroadcastMessageWorker($id: ID!) {
         message(id: $id) {
           id
           message

--- a/app/workers/broadcast_now_playing_worker.rb
+++ b/app/workers/broadcast_now_playing_worker.rb
@@ -21,7 +21,7 @@ class BroadcastNowPlayingWorker
 
   def query # rubocop:disable Metrics/MethodLength
     %(
-      query($id: ID!) {
+      query BroadcastNowPlayingWorker($id: ID!) {
         room(id: $id) {
           currentRecord {
             id

--- a/app/workers/broadcast_playlist_worker.rb
+++ b/app/workers/broadcast_playlist_worker.rb
@@ -17,7 +17,7 @@ class BroadcastPlaylistWorker
 
   def query
     %(
-      query($roomId: ID!) {
+      query BroadcastPlaylistWorker($roomId: ID!) {
         roomPlaylist(roomId: $roomId) {
           id, order, song { id, name }, user { email, name }
         }

--- a/app/workers/broadcast_users_worker.rb
+++ b/app/workers/broadcast_users_worker.rb
@@ -17,7 +17,7 @@ class BroadcastUsersWorker
 
   def query
     %(
-      query($id: ID!) {
+      query BroadcastUsersWorker($id: ID!) {
         room(id: $id) {
           users {
             id

--- a/config/application.rb
+++ b/config/application.rb
@@ -51,6 +51,8 @@ module MusicboxApi
       end
     end
 
+    config.skylight.probes += %w[graphql]
+
     config.generators do |g|
       g.orm :active_record, primary_key_type: :uuid
       g.orm :active_record, foreign_key_type: :uuid


### PR DESCRIPTION
@go-between/folks 

Adds a graphql probe so that skylight can separate out queries by name.  Also adds query names to our own broadcast workers (we're already using them for all queries from the react app).