### PR TITLE
Pump it up

### DIFF
--- a/app/channels/record_listens_channel.rb
+++ b/app/channels/record_listens_channel.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+class RecordListensChannel < ApplicationCable::Channel
+end

--- a/app/graphql/mutations/record_listen_create.rb
+++ b/app/graphql/mutations/record_listen_create.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+module Mutations
+  class RecordListenCreate < Mutations::BaseMutation
+    argument :record_id, ID, required: true
+    argument :approval, Int, required: true
+
+    field :record_listen, Types::RecordListenType, null: true
+    field :errors, [String], null: true
+
+    def resolve(record_id:, approval:)
+      unless record_playing?(record_id)
+        return {
+          record_listen: nil,
+          errors: ["Record must be playing in the active room"]
+        }
+      end
+
+      approval = ensure_approval_range(approval)
+      listen = ensure_record_listen!(record_id)
+      listen.update!(approval: approval) if listen.approval != approval
+
+      { record_listen: listen, errors: [] }
+    end
+
+    private
+
+    def ensure_approval_range(approval)
+      return 0 if approval.negative?
+
+      [approval, 3].min
+    end
+
+    def ensure_record_listen!(record_id)
+      record = RoomPlaylistRecord.find(record_id)
+      RecordListen.find_or_create_by!(room_playlist_record_id: record_id, song_id: record.song_id, user_id: current_user.id)
+    end
+
+    def record_playing?(record_id)
+      record_id == current_user&.active_room&.current_record_id
+    end
+  end
+end

--- a/app/graphql/mutations/record_listen_create.rb
+++ b/app/graphql/mutations/record_listen_create.rb
@@ -20,6 +20,7 @@ module Mutations
       listen = ensure_record_listen!(record_id)
       listen.update!(approval: approval) if listen.approval != approval
 
+      BroadcastRecordListensWorker.perform_async(record_id)
       { record_listen: listen, errors: [] }
     end
 
@@ -33,7 +34,11 @@ module Mutations
 
     def ensure_record_listen!(record_id)
       record = RoomPlaylistRecord.find(record_id)
-      RecordListen.find_or_create_by!(room_playlist_record_id: record_id, song_id: record.song_id, user_id: current_user.id)
+      RecordListen.find_or_create_by!(
+        room_playlist_record_id: record_id,
+        song_id: record.song_id,
+        user_id: current_user.id
+      )
     end
 
     def record_playing?(record_id)

--- a/app/graphql/types/mutation_type.rb
+++ b/app/graphql/types/mutation_type.rb
@@ -8,6 +8,8 @@ module Types
     field :message_create, mutation: Mutations::MessageCreate
     field :message_pin, mutation: Mutations::MessagePin
 
+    field :record_listen_create, mutation: Mutations::RecordListenCreate
+
     field :room_activate, mutation: Mutations::RoomActivate
     field :room_create, mutation: Mutations::RoomCreate
 

--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -57,6 +57,22 @@ module Types
       selector.select(room_id: current_user.active_room_id, song_id: song_id)
     end
 
+    field :record_listens, [Types::RecordListenType], null: true, extras: [:lookahead] do
+      argument :record_id, ID, required: true
+    end
+
+    def record_listens(record_id:, lookahead:)
+      includes = []
+      includes << :room_playlist_record if lookahead.selects?(:room_playlist_record)
+      includes << :song if lookahead.selects?(:song)
+      includes << :user if lookahead.selects?(:user)
+
+      listens = RecordListen
+      listens = listens.includes(includes) if includes.any?
+
+      listens.where(room_playlist_record_id: record_id)
+    end
+
     field :room, Types::RoomType, null: true do
       argument :id, ID, required: true
     end

--- a/app/graphql/types/record_listen_type.rb
+++ b/app/graphql/types/record_listen_type.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module Types
+  class RecordListenType < Types::BaseObject
+    graphql_name "RecordListen"
+
+    field :id, ID, null: false
+    field :approval, Int, null: false
+
+    field :room_playlist_record, Types::RoomPlaylistRecordType, null: false
+    field :song, Types::SongType, null: false
+    field :user, Types::UserType, null: false
+  end
+end

--- a/app/models/record_listen.rb
+++ b/app/models/record_listen.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class RecordListen < ApplicationRecord
+  belongs_to :room_playlist_record
+  belongs_to :song
+  belongs_to :user
+end

--- a/app/models/room_playlist_record.rb
+++ b/app/models/room_playlist_record.rb
@@ -4,6 +4,7 @@ class RoomPlaylistRecord < ApplicationRecord
   belongs_to :room
   belongs_to :song
   belongs_to :user
+  has_many :record_listens
 
   enum play_state: {
     played: "played",

--- a/app/workers/broadcast_now_playing_worker.rb
+++ b/app/workers/broadcast_now_playing_worker.rb
@@ -28,6 +28,7 @@ class BroadcastNowPlayingWorker
             playedAt
             song {
               id
+              durationInSeconds
               name
               youtubeId
             }

--- a/app/workers/broadcast_record_listens_worker.rb
+++ b/app/workers/broadcast_record_listens_worker.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+class BroadcastRecordListensWorker
+  include Sidekiq::Worker
+  sidekiq_options queue: "broadcast_record_listens"
+
+  def perform(record_id)
+    room = Room.find_by(current_record_id: record_id)
+    return if room.blank?
+
+    listens = MusicboxApiSchema.execute(
+      query: query,
+      context: { override_current_user: true },
+      variables: { recordId: record_id }
+    )
+    RecordListensChannel.broadcast_to(room, listens.to_h)
+  end
+
+  private
+
+  def query
+    %(
+      query BroadcastRecordListensWorker($recordId: ID!) {
+        recordListens(recordId: $recordId) {
+          id
+          approval
+          user {
+            id
+          }
+        }
+      }
+    )
+  end
+end

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -6,5 +6,6 @@
   - [broadcast_message, 1]
   - [broadcast_now_playing, 1]
   - [broadcast_playlist, 1]
+  - [broadcast_record_listens, 1]
   - [broadcast_users, 1]
   - [email_invitations, 1]

--- a/db/migrate/20200318014102_create_listens_table.rb
+++ b/db/migrate/20200318014102_create_listens_table.rb
@@ -1,0 +1,15 @@
+class CreateListensTable < ActiveRecord::Migration[6.0]
+  def change
+    create_table :record_listens, id: :uuid do |t|
+      t.uuid :room_playlist_record_id
+      t.uuid :song_id
+      t.uuid :user_id
+      t.integer :approval, default: 0, null: false
+
+      t.timestamps
+
+      t.index :room_playlist_record_id
+      t.index :song_id
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_03_07_232816) do
+ActiveRecord::Schema.define(version: 2020_03_18_014102) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_trgm"
@@ -79,6 +79,17 @@ ActiveRecord::Schema.define(version: 2020_03_07_232816) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["uid"], name: "index_oauth_applications_on_uid", unique: true
+  end
+
+  create_table "record_listens", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.uuid "room_playlist_record_id"
+    t.uuid "song_id"
+    t.uuid "user_id"
+    t.integer "approval", default: 0, null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["room_playlist_record_id"], name: "index_record_listens_on_room_playlist_record_id"
+    t.index ["song_id"], name: "index_record_listens_on_song_id"
   end
 
   create_table "room_playlist_records", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|

--- a/spec/models/record_listen_spec.rb
+++ b/spec/models/record_listen_spec.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe RecordListen, type: :model do
+  describe "relationships" do
+    it "can belong to a record, song and user" do
+      record = create(:room_playlist_record)
+      song = create(:song)
+      user = create(:user)
+
+      listen = described_class.create!(room_playlist_record: record, song: song, user: user)
+
+      expect(listen.reload.room_playlist_record).to eq(record)
+      expect(listen.reload.song).to eq(song)
+      expect(listen.reload.user).to eq(user)
+    end
+  end
+end

--- a/spec/models/room_playlist_record_spec.rb
+++ b/spec/models/room_playlist_record_spec.rb
@@ -3,26 +3,32 @@
 require "rails_helper"
 
 RSpec.describe RoomPlaylistRecord, type: :model do
+  let(:song) { create(:song) }
+  let(:room) { create(:room) }
+  let(:user) { create(:user) }
+
   describe "relationships" do
     it "can belong to a room, song and user" do
-      song = create(:song)
-      room = create(:room)
-      user = create(:user)
-
       record = described_class.create!(song: song, room: room, user: user)
 
       expect(record.reload.song).to eq(song)
       expect(record.reload.room).to eq(room)
       expect(record.reload.user).to eq(user)
     end
+
+    it "has many record listens" do
+      record = described_class.create!(song: song, room: room, user: user)
+
+      l1 = RecordListen.create!(room_playlist_record: record, song: song, user: user)
+      l2 = RecordListen.create!(room_playlist_record: record, song: song, user: user)
+      l3 = RecordListen.create!(room_playlist_record: record, song: song, user: user)
+
+      expect(record.reload.record_listens).to match_array([l1, l2, l3])
+    end
   end
 
   describe "methods" do
     let(:record) do
-      song = create(:song)
-      room = create(:room)
-      user = create(:user)
-
       described_class.create!(song: song, room: room, user: user)
     end
 

--- a/spec/mutations/record_listen_create_spec.rb
+++ b/spec/mutations/record_listen_create_spec.rb
@@ -43,6 +43,7 @@ RSpec.describe "Record Listen Create", type: :request do
       expect(listen.song).to eq(record.song)
       expect(listen.user).to eq(current_user)
       expect(listen.approval).to eq(1)
+      expect(BroadcastRecordListensWorker).to have_enqueued_sidekiq_job(record.id)
     end
 
     it "updates an existing record listen" do
@@ -59,6 +60,7 @@ RSpec.describe "Record Listen Create", type: :request do
       listen_id = json_body.dig(:data, :recordListenCreate, :recordListen, :id)
       expect(listen_id).to eq(listen.id)
       expect(listen.reload.approval).to eq(3)
+      expect(BroadcastRecordListensWorker).to have_enqueued_sidekiq_job(record.id)
     end
   end
 end

--- a/spec/mutations/record_listen_create_spec.rb
+++ b/spec/mutations/record_listen_create_spec.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Record Listen Create", type: :request do
+  include AuthHelper
+  include JsonHelper
+
+  def query
+    %(
+      mutation RecordListen($recordId: ID!, $approval: Int!) {
+        recordListenCreate(input:{
+          recordId: $recordId,
+          approval: $approval
+        }) {
+          recordListen {
+            id
+          }
+          errors
+        }
+      }
+    )
+  end
+
+  let(:record) { create(:room_playlist_record) }
+  let(:room) { create(:room, current_record: record) }
+  let(:current_user) { create(:user, active_room: room) }
+
+  describe "success" do
+    it "creates a record listen" do
+      expect do
+        graphql_request(
+          query: query,
+          user: current_user,
+          variables: { recordId: record.id, approval: 1 }
+        )
+      end.to change(RecordListen, :count).by(1)
+
+      listen_id = json_body.dig(:data, :recordListenCreate, :recordListen, :id)
+      listen = RecordListen.find(listen_id)
+
+      expect(listen.room_playlist_record).to eq(record)
+      expect(listen.song).to eq(record.song)
+      expect(listen.user).to eq(current_user)
+      expect(listen.approval).to eq(1)
+    end
+
+    it "updates an existing record listen" do
+      listen = RecordListen.create!(room_playlist_record: record, song: record.song, user: current_user, approval: 0)
+
+      expect do
+        graphql_request(
+          query: query,
+          user: current_user,
+          variables: { recordId: record.id, approval: 3 }
+        )
+      end.not_to change(RecordListen, :count)
+
+      listen_id = json_body.dig(:data, :recordListenCreate, :recordListen, :id)
+      expect(listen_id).to eq(listen.id)
+      expect(listen.reload.approval).to eq(3)
+    end
+  end
+end

--- a/spec/queries/record_listens_spec.rb
+++ b/spec/queries/record_listens_spec.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Record Listens Query", type: :request do
+  include AuthHelper
+  include JsonHelper
+
+  def query
+    %(
+      query RecordListens($recordId: ID!) {
+        recordListens(recordId: $recordId) {
+          id
+          approval
+          roomPlaylistRecord {
+            id
+          }
+          song {
+            id
+          }
+          user {
+            id
+          }
+        }
+      }
+    )
+  end
+
+  let(:record) { create(:room_playlist_record) }
+
+  it "retrieves record listens" do
+    user1 = create(:user)
+    user2 = create(:user)
+    user3 = create(:user)
+    l1 = RecordListen.create!(room_playlist_record: record, song: record.song, user: user1, approval: 1)
+    l2 = RecordListen.create!(room_playlist_record: record, song: record.song, user: user2, approval: 2)
+    l3 = RecordListen.create!(room_playlist_record: record, song: record.song, user: user3, approval: 3)
+
+    graphql_request(
+      query: query,
+      variables: { recordId: record.id },
+      user: user1
+    )
+
+    listens = json_body.dig(:data, :recordListens).map { |m| { id: m[:id], approval: m[:approval] } }
+    expected_listens = [{ id: l1.id, approval: 1 }, { id: l2.id, approval: 2 }, { id: l3.id, approval: 3 }]
+    expect(listens).to match_array(expected_listens)
+  end
+end

--- a/spec/workers/broadcast_record_listens_worker_spec.rb
+++ b/spec/workers/broadcast_record_listens_worker_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+RSpec.describe BroadcastRecordListensWorker, type: :worker do
+  let(:record) { create(:room_playlist_record) }
+  let(:room) { create(:room, current_record: record) }
+  let(:worker) { described_class.new }
+  let(:user1) { create(:user) }
+  let(:user2) { create(:user) }
+
+  describe "#perform" do
+    it "broadcasts the record listens for the given record" do
+      RecordListen.create!(user: user1, room_playlist_record: record, song: record.song, approval: 1)
+      RecordListen.create!(user: user2, room_playlist_record: record, song: record.song, approval: 3)
+
+      expect do
+        worker.perform(record.id)
+      end.to(have_broadcasted_to(room).from_channel(RecordListensChannel).with do |msg|
+        listens = msg.dig(:data, :recordListens)
+        expect(listens.size).to eq(2)
+
+        user1_listen = listens.find { |l| l.dig(:user, :id) == user1.id }
+        user2_listen = listens.find { |l| l.dig(:user, :id) == user2.id }
+
+        expect(user1_listen[:approval]).to eq(1)
+        expect(user2_listen[:approval]).to eq(3)
+      end)
+    end
+  end
+end


### PR DESCRIPTION
@go-between/folks 

Adds a `record_listens` table to record when a user has engaged with a particular room playlist record, currently only via "approving" the song.  Adds associated model and relationships to users, etc.  Adds a query to retrieve record listens, and a mutation to make new ones.  Adds a websocket channel and a broadcast worker so that folks may be notified when a new listen is created.