### PR TITLE
Add played at, id of room playlist record to messages

### DIFF
--- a/app/workers/broadcast_message_worker.rb
+++ b/app/workers/broadcast_message_worker.rb
@@ -23,6 +23,10 @@ class BroadcastMessageWorker
           message
           pinned
           createdAt
+          roomPlaylistRecord {
+            id
+            playedAt
+          }
           song {
             name
           }


### PR DESCRIPTION
@go-between/folks 

Adds support for returning room playlist record's id and played at with a message broadcast.  Supports this pr:  https://github.com/go-between/musicbox/compare/song-name?expand=1