### PR TITLE
Better invitations

### DIFF
--- a/app/graphql/mutations/invitation_accept.rb
+++ b/app/graphql/mutations/invitation_accept.rb
@@ -4,7 +4,7 @@ module Mutations
   class InvitationAccept < Mutations::BaseMutation
     class InvitationAcceptInputObject < Types::BaseInputObject
       argument :name, String, required: true
-      argument :email, String, required: true
+      argument :email, Types::EmailType, required: true
       argument :password, String, required: true
       argument :token, ID, required: true
     end
@@ -18,7 +18,7 @@ module Mutations
     end
 
     def resolve(invitation:)
-      invite = Invitation.find_by(email: invitation[:email].downcase, token: invitation[:token])
+      invite = Invitation.find_by(email: invitation[:email], token: invitation[:token])
       return { errors: ["Invalid invitation"] } if invite.blank?
 
       invited_user = ensure_invited_user!(invitation)

--- a/app/graphql/mutations/invitation_accept.rb
+++ b/app/graphql/mutations/invitation_accept.rb
@@ -3,7 +3,7 @@
 module Mutations
   class InvitationAccept < Mutations::BaseMutation
     class InvitationAcceptInputObject < Types::BaseInputObject
-      argument :name, String, required: true
+      argument :name, String, required: false
       argument :email, Types::EmailType, required: true
       argument :password, String, required: true
       argument :token, ID, required: true

--- a/app/graphql/mutations/team_create.rb
+++ b/app/graphql/mutations/team_create.rb
@@ -3,7 +3,7 @@
 module Mutations
   class TeamCreate < Mutations::BaseMutation
     class TeamOwnerInputObject < Types::BaseInputObject
-      argument :email, String, required: true
+      argument :email, Types::EmailType, required: true
       argument :name, String, required: true
       argument :password, String, required: true
     end

--- a/app/graphql/types/email_type.rb
+++ b/app/graphql/types/email_type.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module Types
+  class EmailType < Types::BaseScalar
+    def self.coerce_input(value, _context)
+      value&.downcase
+    end
+
+    def self.coerce_result(value, _context)
+      value
+    end
+  end
+end

--- a/app/graphql/types/invitation_type.rb
+++ b/app/graphql/types/invitation_type.rb
@@ -8,6 +8,7 @@ module Types
     field :name, String, null: false
     field :invitation_state, String, null: false
     field :inviting_user, Types::UserType, null: false
+    field :invited_user, Types::UserType, null: true
     field :team, Types::TeamType, null: false
   end
 end

--- a/app/models/invitation.rb
+++ b/app/models/invitation.rb
@@ -3,6 +3,7 @@
 class Invitation < ApplicationRecord
   belongs_to :team
   belongs_to :inviting_user, foreign_key: :invited_by_id, class_name: "User"
+  belongs_to :invited_user, foreign_key: :email, primary_key: :email, class_name: "User", optional: true
 
   def self.token
     SecureRandom.uuid

--- a/app/workers/email_invitation_worker.rb
+++ b/app/workers/email_invitation_worker.rb
@@ -24,7 +24,7 @@ class EmailInvitationWorker
       inviter_name: invitation.inviting_user.name,
       team_name: invitation.team.name,
       token: invitation.token,
-      email: invitation.email
+      email: URI.encode_www_form_component(invitation.email)
     }
 
     req = Net::HTTP::Post.new(uri)

--- a/spec/models/invitation_spec.rb
+++ b/spec/models/invitation_spec.rb
@@ -12,6 +12,16 @@ RSpec.describe Invitation, type: :model do
       expect(invitation.inviting_user).to eq(user)
       expect(invitation.team).to eq(team)
     end
+
+    it "may belong to an existing invited user" do
+      invited_user = create(:user, email: "a@a.a")
+
+      inviting_user = create(:user)
+      team = create(:team)
+      invitation = described_class.create!(inviting_user: inviting_user, team: team, email: "a@a.a")
+
+      expect(invitation.invited_user).to eq(invited_user)
+    end
   end
 
   describe "#self.token" do

--- a/spec/mutations/invitation_accept_spec.rb
+++ b/spec/mutations/invitation_accept_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe "Invitation Create", type: :request do
 
   def query
     %(
-      mutation InvitationAccept($email: String!, $password: String!, $token: ID!, $name: String!){
+      mutation InvitationAccept($email: Email!, $password: String!, $token: ID!, $name: String!){
         invitationAccept(input:{
           invitation: {
             email: $email,
@@ -39,7 +39,7 @@ RSpec.describe "Invitation Create", type: :request do
   describe "success" do
     it "accepts an invitation" do
       variables = {
-        email: "an-invited-user@atdot.com",
+        email: "an-INVITED-user@atdot.com",
         password: "foobar",
         token: "fbb586a9-b798-4a31-a634-66d28a661375",
         name: "Blorg Blargaborg"
@@ -65,7 +65,7 @@ RSpec.describe "Invitation Create", type: :request do
       user = User.create!(email: "an-invited-user@atdot.com", password: "foobar", teams: [other_team])
 
       variables = {
-        email: "an-invited-user@atdot.com",
+        email: "an-invited-USER@atdot.com",
         password: "foobar",
         token: "fbb586a9-b798-4a31-a634-66d28a661375",
         name: "Blorg Blargaborg"

--- a/spec/mutations/invitation_accept_spec.rb
+++ b/spec/mutations/invitation_accept_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe "Invitation Create", type: :request do
 
   def query
     %(
-      mutation InvitationAccept($email: Email!, $password: String!, $token: ID!, $name: String!){
+      mutation InvitationAccept($email: Email!, $password: String!, $token: ID!, $name: String){
         invitationAccept(input:{
           invitation: {
             email: $email,

--- a/spec/mutations/team_create_spec.rb
+++ b/spec/mutations/team_create_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe "Invitation Create", type: :request do
     it "creates a team for a new user" do
       variables = {
         teamOwner: {
-          email: "team-owner@atdot.com",
+          email: "TEAM-owner@ATDOT.com",
           password: "foobar",
           name: "Trickster"
         },
@@ -39,6 +39,7 @@ RSpec.describe "Invitation Create", type: :request do
       end.to change(User, :count).by(1).and(change(Team, :count).by(1))
 
       team = Team.find_by(name: "FrogTown")
+      # Ensure email is downcased
       user = User.find_by(email: "team-owner@atdot.com")
       expect(team.owner).to eq(user)
       expect(user.valid_password?("foobar")).to eq(true)
@@ -52,7 +53,7 @@ RSpec.describe "Invitation Create", type: :request do
       User.create!(email: "team-owner@atdot.com", password: "foobar", teams: [])
       variables = {
         teamOwner: {
-          email: "team-owner@atdot.com",
+          email: "team-OWNER@atdot.COM",
           password: "foobar",
           name: "Trickster"
         },


### PR DESCRIPTION
@go-between/folks 

A handful of user-related fixes:
  - Allows invitation accept's name to be optional
  - Ensures emails are stored in downcase
  - Allows the `invited_user` to be optional associated with an invitation via email