### PR TITLE
Little fixes

### DIFF
--- a/app/channels/team_channel.rb
+++ b/app/channels/team_channel.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class TeamChannel < ApplicationCable::Channel
+  def subscribed
+    return reject if current_user.active_team.blank?
+
+    stream_for current_user.active_team
+  end
+end

--- a/app/graphql/mutations/room_activate.rb
+++ b/app/graphql/mutations/room_activate.rb
@@ -17,7 +17,7 @@ module Mutations
       end
 
       previous_room_id = current_user.active_room_id
-      current_user.update!(active_room_id: room_id)
+      current_user.update!(active_room_id: room_id, active_team_id: room.team_id)
 
       BroadcastUsersWorker.perform_async(previous_room_id) if previous_room_id.present?
       BroadcastUsersWorker.perform_async(room_id)

--- a/app/graphql/mutations/team_activate.rb
+++ b/app/graphql/mutations/team_activate.rb
@@ -3,13 +3,19 @@
 module Mutations
   class TeamActivate < Mutations::BaseMutation
     argument :team_id, ID, required: true
+
+    field :team, Types::TeamType, null: true
     field :errors, [String], null: true
 
     def resolve(team_id:)
-      return { errors: ["User does not belong to this team"] } unless current_user.teams.exists?(id: team_id)
+      return { team: nil, errors: ["User does not belong to this team"] } unless current_user.teams.exists?(id: team_id)
 
       current_user.update!(active_team_id: team_id)
-      { errors: [] }
+
+      {
+        team: current_user.active_team,
+        errors: []
+      }
     end
   end
 end

--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -142,7 +142,19 @@ module Types
     end
 
     def tags
+      confirm_current_user!
       current_user.tags
+    end
+
+    field :team, Types::TeamType, null: true do
+      argument :id, ID, required: true
+    end
+
+    def team(id:)
+      confirm_current_user!
+      teams = Team.where(id: id)
+      teams = teams.where(id: current_user.teams) if current_user.present?
+      teams.first
     end
 
     field :user, Types::UserType, null: false do

--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -128,17 +128,12 @@ module Types
       argument :tag_ids, [ID], required: false
     end
 
-    def songs(query: nil, tag_ids: []) # rubocop:disable Metrics/AbcSize
+    def songs(query: nil, tag_ids: [])
       confirm_current_user!
 
       library = current_user.songs
       library = library.where(Song.arel_table[:name].matches("%#{query}%")) if query.present?
-
-      if tag_ids.present?
-        # TODO: make it fast
-        user_tag_ids = current_user.tags.where(id: tag_ids).pluck(:id)
-        library = library.select { |song| song.tags.exists?(id: user_tag_ids) }
-      end
+      library = library.joins(:tag_songs).where(tags_songs: { tag_id: tag_ids }).distinct if tag_ids.present?
 
       library
     end

--- a/app/graphql/types/team_type.rb
+++ b/app/graphql/types/team_type.rb
@@ -6,5 +6,6 @@ module Types
 
     field :id, ID, null: false
     field :name, String, null: true
+    field :rooms, [Types::RoomType], null: false
   end
 end

--- a/app/workers/broadcast_team_worker.rb
+++ b/app/workers/broadcast_team_worker.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+class BroadcastTeamWorker
+  include Sidekiq::Worker
+  sidekiq_options queue: "broadcast_team"
+
+  def perform(team_id)
+    queue = MusicboxApiSchema.execute(
+      query: query,
+      context: { override_current_user: true },
+      variables: { id: team_id }
+    )
+    TeamChannel.broadcast_to(Team.find(team_id), queue.to_h)
+  end
+
+  private
+
+  def query
+    %(
+      query BroadcastTeamWorker($id: ID!) {
+        team(id: $id) {
+          rooms {
+            id
+            name
+            currentSong {
+              name
+            }
+          }
+        }
+      }
+    )
+  end
+end

--- a/app/workers/queue_management_worker.rb
+++ b/app/workers/queue_management_worker.rb
@@ -8,6 +8,7 @@ class QueueManagementWorker
     room = Room.find(room_id)
     return unless update_room!(room)
 
+    BroadcastTeamWorker.perform_async(room.team_id)
     BroadcastNowPlayingWorker.perform_async(room_id)
     BroadcastPlaylistWorker.perform_async(room_id)
   end

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -7,5 +7,6 @@
   - [broadcast_now_playing, 1]
   - [broadcast_playlist, 1]
   - [broadcast_record_listens, 1]
+  - [broadcast_team, 1]
   - [broadcast_users, 1]
   - [email_invitations, 1]


### PR DESCRIPTION
@go-between/folks 

This PR:
  - Adds a `TeamsChannel` for action cable messages bound in a team context
  - Adds a `team` query to furnish the channel with data
  - Sends a message on the channel whenever a song in a room changes over
  - Hopefully makes tag search faster for messages