### PR TITLE
Broadcast users on team

### DIFF
--- a/app/channels/users_channel.rb
+++ b/app/channels/users_channel.rb
@@ -12,8 +12,7 @@ class UsersChannel < ApplicationCable::Channel
   def remove_from_room!
     return if current_user.active_room_id.blank?
 
-    previous_room = current_user.active_room_id
     current_user.update!(active_room: nil)
-    BroadcastUsersWorker.perform_async(previous_room)
+    BroadcastTeamWorker.perform_async(current_user.active_team_id)
   end
 end

--- a/app/graphql/mutations/room_activate.rb
+++ b/app/graphql/mutations/room_activate.rb
@@ -16,11 +16,9 @@ module Mutations
         }
       end
 
-      previous_room_id = current_user.active_room_id
       current_user.update!(active_room_id: room_id, active_team_id: room.team_id)
 
-      BroadcastUsersWorker.perform_async(previous_room_id) if previous_room_id.present?
-      BroadcastUsersWorker.perform_async(room_id)
+      BroadcastTeamWorker.perform_async(current_user.active_team_id)
 
       {
         room: room,

--- a/app/graphql/mutations/team_activate.rb
+++ b/app/graphql/mutations/team_activate.rb
@@ -10,7 +10,11 @@ module Mutations
     def resolve(team_id:)
       return { team: nil, errors: ["User does not belong to this team"] } unless current_user.teams.exists?(id: team_id)
 
+      previous_team_id = current_user.active_team_id
       current_user.update!(active_team_id: team_id)
+
+      BroadcastTeamWorker.perform_async(previous_team_id) if previous_team_id.present?
+      BroadcastTeamWorker.perform_async(team_id)
 
       {
         team: current_user.active_team,

--- a/app/graphql/types/room_playlist_record_type.rb
+++ b/app/graphql/types/room_playlist_record_type.rb
@@ -7,6 +7,7 @@ module Types
     field :id, ID, null: false
     field :order, Int, null: false
     field :played_at, Types::DateTimeType, null: true
+    field :record_listens, [Types::RecordListenType], null: false
     field :room, Types::RoomType, null: false
     field :song, Types::SongType, null: false
     field :user, Types::UserType, null: false

--- a/app/lib/room_playlist.rb
+++ b/app/lib/room_playlist.rb
@@ -1,10 +1,11 @@
 # frozen_string_literal: true
 
 class RoomPlaylist
-  attr_reader :room
+  attr_reader :room, :playlist_records
 
-  def initialize(room)
+  def initialize(room, playlist_records)
     @room = room
+    @playlist_records = playlist_records
   end
 
   def generate_playlist
@@ -27,7 +28,7 @@ class RoomPlaylist
   def waiting_songs
     return @waiting_songs if defined? @waiting_songs
 
-    @waiting_songs = RoomPlaylistRecord.includes(:song, :user).where(room_id: room.id, play_state: "waiting").to_a
+    @waiting_songs = playlist_records.where(room_id: room.id, play_state: "waiting").to_a
   end
 
   def waiting_songs_for_user(user_id)

--- a/app/workers/broadcast_team_worker.rb
+++ b/app/workers/broadcast_team_worker.rb
@@ -15,7 +15,7 @@ class BroadcastTeamWorker
 
   private
 
-  def query
+  def query # rubocop:disable Metrics/MethodLength
     %(
       query BroadcastTeamWorker($id: ID!) {
         team(id: $id) {
@@ -23,6 +23,11 @@ class BroadcastTeamWorker
             id
             name
             currentSong {
+              name
+            }
+            users {
+              id
+              email
               name
             }
           }

--- a/app/workers/queue_management_worker.rb
+++ b/app/workers/queue_management_worker.rb
@@ -36,7 +36,8 @@ class QueueManagementWorker
   end
 
   def next_record_in_playlist(room)
-    RoomPlaylist.new(room).generate_playlist.first
+    relation = RoomPlaylistRecord.includes(:song, :user)
+    RoomPlaylist.new(room, relation).generate_playlist.first
   end
 
   def remove_stale_user_from_room!(room)

--- a/spec/integration/requests_spec.rb
+++ b/spec/integration/requests_spec.rb
@@ -39,14 +39,16 @@ RSpec.describe "Requests Integration", type: :request do
           query: room_activate_mutation(room_id: room.id),
           user: truman
         )
-      end.to(broadcast_to(UsersChannel.broadcasting_for(room)).with do |data|
-        has_truman = data.dig("data", "room", "users").any? { |d| d["id"] == truman.id }
+      end.to(broadcast_to(TeamChannel.broadcasting_for(team)).with do |data|
+        room_message = data.dig(:data, :team, :rooms).find { |r| r[:id] == room.id }
+
+        has_truman = room_message[:users].any? { |d| d["id"] == truman.id }
         expect(has_truman).to eq(true)
 
-        has_dan = data.dig("data", "room", "users").any? { |d| d["id"] == dan.id }
+        has_dan = room_message[:users].any? { |d| d["id"] == dan.id }
         expect(has_dan).to eq(false)
 
-        has_sean = data.dig("data", "room", "users").any? { |d| d["id"] == sean.id }
+        has_sean = room_message[:users].any? { |d| d["id"] == sean.id }
         expect(has_sean).to eq(false)
       end)
 
@@ -55,14 +57,16 @@ RSpec.describe "Requests Integration", type: :request do
           query: room_activate_mutation(room_id: room.id),
           user: dan
         )
-      end.to(broadcast_to(UsersChannel.broadcasting_for(room)).with do |data|
-        has_truman = data.dig("data", "room", "users").any? { |d| d["id"] == truman.id }
+      end.to(broadcast_to(TeamChannel.broadcasting_for(team)).with do |data|
+        room_message = data.dig(:data, :team, :rooms).find { |r| r[:id] == room.id }
+
+        has_truman = room_message[:users].any? { |d| d["id"] == truman.id }
         expect(has_truman).to eq(true)
 
-        has_dan = data.dig("data", "room", "users").any? { |d| d["id"] == dan.id }
+        has_dan = room_message[:users].any? { |d| d["id"] == dan.id }
         expect(has_dan).to eq(true)
 
-        has_sean = data.dig("data", "room", "users").any? { |d| d["id"] == sean.id }
+        has_sean = room_message[:users].any? { |d| d["id"] == sean.id }
         expect(has_sean).to eq(false)
       end)
 
@@ -71,14 +75,16 @@ RSpec.describe "Requests Integration", type: :request do
           query: room_activate_mutation(room_id: room.id),
           user: sean
         )
-      end.to(broadcast_to(UsersChannel.broadcasting_for(room)).with do |data|
-        has_truman = data.dig("data", "room", "users").any? { |d| d["id"] == truman.id }
+      end.to(broadcast_to(TeamChannel.broadcasting_for(team)).with do |data|
+        room_message = data.dig(:data, :team, :rooms).find { |r| r[:id] == room.id }
+
+        has_truman = room_message[:users].any? { |d| d["id"] == truman.id }
         expect(has_truman).to eq(true)
 
-        has_dan = data.dig("data", "room", "users").any? { |d| d["id"] == dan.id }
+        has_dan = room_message[:users].any? { |d| d["id"] == dan.id }
         expect(has_dan).to eq(true)
 
-        has_sean = data.dig("data", "room", "users").any? { |d| d["id"] == sean.id }
+        has_sean = room_message[:users].any? { |d| d["id"] == sean.id }
         expect(has_sean).to eq(true)
       end)
 

--- a/spec/lib/room_playlist_spec.rb
+++ b/spec/lib/room_playlist_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe RoomPlaylist do
   let(:user_2) { create(:user) }
   let(:user_3) { create(:user) }
   let(:room) { create(:room, user_rotation: [user_1.id, user_2.id, user_3.id]) }
+  let(:relation) { RoomPlaylistRecord.includes(:song, :user) }
 
   describe "#waiting" do
     it "thes whole room queue" do
@@ -19,14 +20,14 @@ RSpec.describe RoomPlaylist do
       record5 = create(:room_playlist_record, room: room, user: user_2, order: 2, play_state: "waiting")
       record6 = create(:room_playlist_record, room: room, user: user_3, order: 20, play_state: "waiting")
 
-      playlist = described_class.new(room)
+      playlist = described_class.new(room, relation)
 
       expect(playlist.generate_playlist).to eq([record3, record4, record5, record6])
     end
 
     it "returns an empty queue when no users are in rotation" do
       room.update!(user_rotation: [])
-      playlist = described_class.new(room)
+      playlist = described_class.new(room, relation)
 
       expect(playlist.generate_playlist).to be_empty
     end

--- a/spec/mutations/room_activate_spec.rb
+++ b/spec/mutations/room_activate_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe "Room Activate", type: :request do
         query: room_activate_mutation(room_id: room.id),
         user: current_user
       )
-      expect(BroadcastUsersWorker).to have_enqueued_sidekiq_job(room.id)
+      expect(BroadcastTeamWorker).to have_enqueued_sidekiq_job(room.team_id)
     end
   end
 

--- a/spec/queries/room_playlist_spec.rb
+++ b/spec/queries/room_playlist_spec.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Messages Query", type: :request do
+  include AuthHelper
+  include JsonHelper
+
+  let(:team) { create(:team) }
+  let(:room) { create(:room, team: team) }
+  let(:star_fighter) { create(:song, name: "Star Fighter", duration_in_seconds: 100) }
+  let(:hootsforce) { create(:song, name: "Hootsforce", duration_in_seconds: 100) }
+  let(:truman) { create(:user, name: "truman", teams: [team], songs: [star_fighter, hootsforce]) }
+  let(:dan) { create(:user, name: "dan", teams: [team], songs: [star_fighter, hootsforce]) }
+  let!(:play_future1) do
+    create(:room_playlist_record, song: star_fighter, user: truman, room: room, play_state: "waiting", order: 1)
+  end
+  let!(:play_future2) do
+    create(:room_playlist_record, song: hootsforce, user: truman, room: room, play_state: "waiting", order: 2)
+  end
+  let!(:play_future3) do
+    create(:room_playlist_record, song: star_fighter, user: dan, room: room, play_state: "waiting", order: 1)
+  end
+  let!(:play_future4) do
+    create(:room_playlist_record, song: hootsforce, user: dan, room: room, play_state: "waiting", order: 2)
+  end
+
+  def query
+    %(
+      query RoomPlaylist($roomId: ID!) {
+        roomPlaylist(roomId: $roomId) {
+          id
+          song {
+            id
+            name
+          }
+          user {
+            email
+            name
+          }
+        }
+      }
+    )
+  end
+
+  context "when requesting future playlist" do
+    it "returns songs in order" do
+      room.update!(user_rotation: [truman.id, dan.id])
+
+      graphql_request(query: query, variables: { roomId: room.id }, user: truman)
+      playlist = json_body.dig(:data, :roomPlaylist).map { |r| r[:id] }
+      expect(playlist).to eq([play_future1.id, play_future3.id, play_future2.id, play_future4.id])
+    end
+  end
+end

--- a/spec/queries/room_playlist_spec.rb
+++ b/spec/queries/room_playlist_spec.rb
@@ -24,11 +24,47 @@ RSpec.describe "Messages Query", type: :request do
   let!(:play_future4) do
     create(:room_playlist_record, song: hootsforce, user: dan, room: room, play_state: "waiting", order: 2)
   end
+  let!(:play_past1) do
+    create(:room_playlist_record,
+           song: star_fighter,
+           user: truman,
+           room: room,
+           play_state: "played",
+           played_at: 4.minute.ago,
+           order: 1)
+  end
+  let!(:play_past2) do
+    create(:room_playlist_record,
+           song: hootsforce,
+           user: truman,
+           room: room,
+           play_state: "played",
+           played_at: 2.minutes.ago,
+           order: 2)
+  end
+  let!(:play_past3) do
+    create(:room_playlist_record,
+           song: star_fighter,
+           user: dan,
+           room: room,
+           play_state: "played",
+           played_at: 3.minutes.ago,
+           order: 1)
+  end
+  let!(:play_past4) do
+    create(:room_playlist_record,
+           song: hootsforce,
+           user: dan,
+           room: room,
+           play_state: "played",
+           played_at: 1.minute.ago,
+           order: 2)
+  end
 
   def query
     %(
-      query RoomPlaylist($roomId: ID!) {
-        roomPlaylist(roomId: $roomId) {
+      query RoomPlaylist($roomId: ID!, $historical: Boolean) {
+        roomPlaylist(roomId: $roomId, historical: $historical) {
           id
           song {
             id
@@ -50,6 +86,14 @@ RSpec.describe "Messages Query", type: :request do
       graphql_request(query: query, variables: { roomId: room.id }, user: truman)
       playlist = json_body.dig(:data, :roomPlaylist).map { |r| r[:id] }
       expect(playlist).to eq([play_future1.id, play_future3.id, play_future2.id, play_future4.id])
+    end
+  end
+
+  context "when requesting previously played records" do
+    it "returns all previously played records" do
+      graphql_request(query: query, variables: { roomId: room.id, historical: true }, user: truman)
+      playlist = json_body.dig(:data, :roomPlaylist).map { |r| r[:id] }
+      expect(playlist).to eq([play_past4.id, play_past2.id, play_past3.id, play_past1.id])
     end
   end
 end


### PR DESCRIPTION
@go-between/folks 

Does a smattering of things:
  - Updates API to broadcast a `TeamMessage` when users enter/leave rooms (rather than individual room messages)
  - Allows the `RoomPlaylist` service class to have its records relation injected so that we can better manage eager loading
  - Allows historical room playlist records to be retrieved