### PR TITLE
Update recommendations API to allow per-song query + bug fix for previously recommended song

### DIFF
--- a/app/graphql/mutations/recommendation_create.rb
+++ b/app/graphql/mutations/recommendation_create.rb
@@ -13,7 +13,7 @@ module Mutations
 
       to_user = User.find(recommend_to_user)
       return { errors: ["User must exist"] } if to_user.blank?
-      return { errors: ["User already has song"] } if to_user.songs.include?(song)
+      return { errors: ["User already has song"] } if UserLibraryRecord.exists?(song: song, user: to_user)
 
       UserLibraryRecord.create!(
         user: to_user,

--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -89,10 +89,10 @@ module Types
       conditions = if song_id
                      { from_user: current_user, song_id: song_id }
                    else
-                     { user: current_user }
+                     { source: "pending_recommendation", user: current_user }
                    end
 
-      records.pending_recommendation.where(conditions)
+      records.where(conditions)
     end
 
     field :record_listens, [Types::RecordListenType], null: true, extras: [:lookahead] do

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -13,7 +13,7 @@ class User < ApplicationRecord
     # exclude records where source is null with a not-equals comparison.
     where(
       arel_table[:source].not_eq("pending_recommendation")
-      .or(arel_table[:source].eq(nil))
+        .or(arel_table[:source].eq(nil))
     )
   }, inverse_of: :user
   has_many :songs, through: :user_library_records

--- a/spec/mutations/recommendation_create_spec.rb
+++ b/spec/mutations/recommendation_create_spec.rb
@@ -39,4 +39,34 @@ RSpec.describe "Recommendation Create", type: :request do
       expect(record.source).to eq("pending_recommendation")
     end
   end
+
+  describe "failure" do
+    it "does not create a recommendation if the user already has the song in their library" do
+      song = create(:song, youtube_id: "the-youtube-id")
+      other_user = create(:user)
+      UserLibraryRecord.create!(user: other_user, song: song, source: "")
+
+      expect do
+        graphql_request(
+          query: query,
+          variables: { youtubeId: "the-youtube-id", recommendToUser: other_user.id },
+          user: current_user
+        )
+      end.to not_change(UserLibraryRecord, :count)
+    end
+
+    it "does not create a recommendation if the user has already been recommended the song" do
+      song = create(:song, youtube_id: "the-youtube-id")
+      other_user = create(:user)
+      UserLibraryRecord.create!(user: other_user, song: song, source: "pending_recommendation")
+
+      expect do
+        graphql_request(
+          query: query,
+          variables: { youtubeId: "the-youtube-id", recommendToUser: other_user.id },
+          user: current_user
+        )
+      end.to not_change(UserLibraryRecord, :count)
+    end
+  end
 end


### PR DESCRIPTION
(pair: @trumanshuck)

1. This lets you query the API for a collection of recommendations per song. Why? Because you may want to see who has already been recommended to so that the app interface can be more robust (which is what drove this change anyhow).

2. This PR also adds test coverage for failure case when user is already recommended a song, and fixes a bug around that.