### PR TITLE
Reordering

### DIFF
--- a/app/graphql/types/library_record_type.rb
+++ b/app/graphql/types/library_record_type.rb
@@ -5,7 +5,7 @@ module Types
     graphql_name "LibraryRecord"
 
     field :id, ID, null: false
-    field :source, String, null: false
+    field :source, String, null: true
 
     field :from_user, Types::UserType, null: true
     field :song, Types::SongType, null: true

--- a/app/graphql/types/order_type.rb
+++ b/app/graphql/types/order_type.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+module Types
+  class OrderType < Types::BaseInputObject
+    argument :field, Types::OrderedFieldType, required: true
+    argument :direction, Types::OrderedDirectionType, required: true
+  end
+end

--- a/app/graphql/types/ordered_direction_type.rb
+++ b/app/graphql/types/ordered_direction_type.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module Types
+  class OrderedDirectionType < Types::BaseScalar
+    def self.coerce_input(value, _context)
+      value&.downcase
+    end
+
+    def self.coerce_result(value, _context)
+      value
+    end
+  end
+end

--- a/app/graphql/types/ordered_field_type.rb
+++ b/app/graphql/types/ordered_field_type.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module Types
+  class OrderedFieldType < Types::BaseScalar
+    def self.coerce_input(value, _context)
+      value&.underscore
+    end
+
+    def self.coerce_result(value, _context)
+      value&.camelize(:lower)
+    end
+  end
+end

--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -168,9 +168,10 @@ module Types
     field :songs, [Types::SongType], null: true, extras: [:lookahead] do
       argument :query, String, required: false
       argument :tag_ids, [ID], required: false
+      argument :order, Types::OrderType, required: false
     end
 
-    def songs(query: nil, tag_ids: [], lookahead:)
+    def songs(query: nil, tag_ids: [], order: nil, lookahead:)
       confirm_current_user!
 
       Selectors::Songs
@@ -179,7 +180,7 @@ module Types
         .with_query(query)
         .with_tags(tag_ids)
         .without_pending_records
-        .songs
+        .songs(order: order)
     end
 
     field :tags, [Types::TagType], null: false do

--- a/app/graphql/types/song_type.rb
+++ b/app/graphql/types/song_type.rb
@@ -5,6 +5,7 @@ module Types
     graphql_name "Song"
 
     field :id, ID, null: false
+    field :created_at, Types::DateTimeType, null: false
     field :description, String, null: true
     field :duration_in_seconds, Int, null: true
     field :license, String, null: true
@@ -14,5 +15,7 @@ module Types
     field :thumbnail_url, String, null: true
     field :youtube_id, ID, null: false
     field :youtube_tags, [String], null: false
+
+    field :user_library_records, [Types::LibraryRecordType], null: false
   end
 end

--- a/app/lib/selectors/songs.rb
+++ b/app/lib/selectors/songs.rb
@@ -10,8 +10,11 @@ module Selectors
       @songs = record_context(lookahead)
     end
 
-    def songs
-      @songs.order(created_at: :asc)
+    def songs(order:)
+      return @songs.order(created_at: :asc) if order.blank?
+      return [] unless Song.column_names.include?(order[:field])
+
+      @songs.order(order[:field] => order[:direction])
     end
 
     def for_user

--- a/spec/queries/songs_spec.rb
+++ b/spec/queries/songs_spec.rb
@@ -8,11 +8,18 @@ RSpec.describe "Songs Query", type: :request do
 
   def query
     %(
-      query Songs($query: String, $tagIds: [ID!]) {
-        songs(query: $query, tagIds: $tagIds) {
+      query Songs($query: String, $tagIds: [ID!], $order: Order) {
+        songs(query: $query, tagIds: $tagIds, order: $order) {
           id
           tags {
             id
+          }
+          userLibraryRecords {
+            id
+            source
+            fromUser {
+              id
+            }
           }
         }
       }
@@ -133,6 +140,88 @@ RSpec.describe "Songs Query", type: :request do
       expect(json_body.dig(:data, :songs).size).to eq(1)
       tag_ids = json_body.dig(:data, :songs, 0, :tags).map { |t| t[:id] }
       expect(tag_ids).to match_array([tag1.id])
+    end
+  end
+
+  describe "when retrieving associated user library records" do
+    let(:song1) { create(:song, created_at: 1.day.ago, name: "CCC") }
+    let(:song2) { create(:song, created_at: 2.days.ago, name: "AAAA") }
+    let(:other_user) { create(:user, name: "the other user") }
+
+    it "only retrieves the user's own library records" do
+      record1 = UserLibraryRecord.create!(user: user, song: song1, from_user: other_user, source: "saved_from_history")
+      record2 = UserLibraryRecord.create!(user: user, song: song2)
+      UserLibraryRecord.create!(user: other_user, song: song1)
+      UserLibraryRecord.create!(user: other_user, song: song2)
+
+      graphql_request(query: query, user: user)
+
+      song1_resp = json_body.dig(:data, :songs).find { |s| s[:id] == song1.id }
+      song2_resp = json_body.dig(:data, :songs).find { |s| s[:id] == song2.id }
+
+      expect(song1_resp.dig(:userLibraryRecords).size).to eq(1)
+      record1_resp = song1_resp.dig(:userLibraryRecords).first
+      expect(record1_resp[:id]).to eq(record1.id)
+      expect(record1_resp[:source]).to eq("saved_from_history")
+      expect(record1_resp.dig(:fromUser, :id)).to eq(other_user.id)
+
+      expect(song2_resp.dig(:userLibraryRecords).size).to eq(1)
+      record2_resp = song2_resp.dig(:userLibraryRecords).first
+      expect(record2_resp[:id]).to eq(record2.id)
+      expect(record2_resp[:source]).to be_nil
+      expect(record2_resp[:fromUser]).to be_nil
+    end
+  end
+
+  describe "ordering" do
+    let(:song1) { create(:song, created_at: 1.day.ago, name: "CCC") }
+    let(:song2) { create(:song, created_at: 2.days.ago, name: "AAAA") }
+    let(:song3) { create(:song, created_at: 3.day.ago, name: "BBBB") }
+
+    it "returns songs in creation order by default" do
+      user.update!(songs: [song1, song2, song3])
+
+      graphql_request(query: query, user: user)
+      song_ids = json_body.dig(:data, :songs).map { |s| s[:id] }
+      expect(song_ids).to eq([song3.id, song2.id, song1.id])
+    end
+
+    it "returns songs in reverse creation order" do
+      user.update!(songs: [song1, song2, song3])
+
+      graphql_request(query: query, user: user, variables: { order: { field: "createdAt", direction: "desc" } })
+      song_ids = json_body.dig(:data, :songs).map { |s| s[:id] }
+      expect(song_ids).to eq([song1.id, song2.id, song3.id])
+    end
+
+    it "returns songs in name order" do
+      user.update!(songs: [song1, song2, song3])
+
+      graphql_request(query: query, user: user, variables: { order: { field: "name", direction: "asc" } })
+      song_ids = json_body.dig(:data, :songs).map { |s| s[:id] }
+      expect(song_ids).to eq([song2.id, song3.id, song1.id])
+    end
+
+    it "returns songs in reverse name order" do
+      user.update!(songs: [song1, song2, song3])
+
+      graphql_request(query: query, user: user, variables: { order: { field: "name", direction: "desc" } })
+      song_ids = json_body.dig(:data, :songs).map { |s| s[:id] }
+      expect(song_ids).to eq([song1.id, song3.id, song2.id])
+    end
+
+    it "returns an empty array when field is invalid" do
+      user.update!(songs: [song1, song2, song3])
+
+      graphql_request(
+        query: query,
+        user: user,
+        variables: { order: { field: "name; DROP TABLE songs", direction: "desc" } }
+      )
+      song_ids = json_body.dig(:data, :songs).map { |s| s[:id] }
+
+      expect(song_ids).to eq([])
+      expect(Song.all).to be_present
     end
   end
 end


### PR DESCRIPTION
@go-between/folks 

Allows an `order` property to be sent with a songs query, also allows a user's own `UserLibraryRecords` to be retrieved.
