### PR TITLE
No duplicate approvals

### DIFF
--- a/db/migrate/20200513040509_allow_library_record_to_associate_to_tags.rb
+++ b/db/migrate/20200513040509_allow_library_record_to_associate_to_tags.rb
@@ -8,7 +8,8 @@ class AllowLibraryRecordToAssociateToTags < ActiveRecord::Migration[6.0]
     add_column :tags_songs, :library_record_id, :uuid
     TagSong.all.each do |tag_song|
       tag = Tag.find(tag_song.tag_id)
-      record = LibraryRecord.find_by!(user_id: tag.user_id, song_id: tag_song.song_id)
+      record = LibraryRecord.find_by(user_id: tag.user_id, song_id: tag_song.song_id)
+      next if record.blank?
       tag_song.update!(library_record_id: record.id)
     end
 

--- a/db/migrate/20200603024043_add_unique_constraint_on_record_listens.rb
+++ b/db/migrate/20200603024043_add_unique_constraint_on_record_listens.rb
@@ -1,0 +1,23 @@
+class AddUniqueConstraintOnRecordListens < ActiveRecord::Migration[6.0]
+  def up
+    # You'd think I'd learn based on how awful the last data migration was.
+    duplicates = RecordListen.group(:room_playlist_record_id, :song_id, :user_id)
+                             .select(:room_playlist_record_id, :song_id, :user_id, "count(1) as total_count")
+                             .having("count(1) > 1")
+                             .to_a
+
+    # Can't create a unique index while there are non-unique records in the database!
+    duplicates.each do |d|
+      all_duplicates = RecordListen.where(room_playlist_record_id: d.room_playlist_record_id, song_id: d.song_id, user_id: d.user_id)
+      # Drop all but one, keeping the most recent.
+      to_remove = all_duplicates.order(:created_at).limit(d.total_count - 1)
+      to_remove.destroy_all
+    end
+
+    add_index :record_listens, [:room_playlist_record_id, :song_id, :user_id], unique: true, name: :unique_record_listens
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_05_15_034314) do
+ActiveRecord::Schema.define(version: 2020_06_03_024043) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_trgm"
@@ -101,6 +101,7 @@ ActiveRecord::Schema.define(version: 2020_05_15_034314) do
     t.integer "approval", default: 0, null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.index ["room_playlist_record_id", "song_id", "user_id"], name: "unique_record_listens", unique: true
     t.index ["room_playlist_record_id"], name: "index_record_listens_on_room_playlist_record_id"
     t.index ["song_id"], name: "index_record_listens_on_song_id"
   end

--- a/spec/models/room_playlist_record_spec.rb
+++ b/spec/models/room_playlist_record_spec.rb
@@ -19,9 +19,9 @@ RSpec.describe RoomPlaylistRecord, type: :model do
     it "has many record listens" do
       record = described_class.create!(song: song, room: room, user: user)
 
-      l1 = RecordListen.create!(room_playlist_record: record, song: song, user: user)
-      l2 = RecordListen.create!(room_playlist_record: record, song: song, user: user)
-      l3 = RecordListen.create!(room_playlist_record: record, song: song, user: user)
+      l1 = RecordListen.create!(room_playlist_record: record, song: song, user: create(:user))
+      l2 = RecordListen.create!(room_playlist_record: record, song: song, user: create(:user))
+      l3 = RecordListen.create!(room_playlist_record: record, song: song, user: create(:user))
 
       expect(record.reload.record_listens).to match_array([l1, l2, l3])
     end


### PR DESCRIPTION
@go-between/folks 

Adds a uniqueness constraint to record-song-user on a `RecordListen`, which should stop the "multiple-approval bug" [we've noticed](https://3.basecamp.com/4361952/buckets/14871813/todos/2712446199).  Allows record listen find-or-create to recover from `RecordNotUnique` exceptions raised by the race condition that causes that bug.