### PR TITLE
Youtube search again

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,7 +16,6 @@ gem "rails", "6.0.3.1"
 
 # Use postgresql as the database for Active Record
 gem "pg", "1.2.1"
-gem "yt", "0.32.5"
 
 gem "dotenv-rails", "2.7.5"
 gem "health_check", "3.0.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -245,8 +245,6 @@ GEM
     websocket-driver (0.7.2)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
-    yt (0.32.5)
-      activesupport
     zeitwerk (2.3.0)
 
 PLATFORMS
@@ -278,7 +276,6 @@ DEPENDENCIES
   spring (= 2.1.0)
   spring-watcher-listen (= 2.0.1)
   webmock (= 3.8.3)
-  yt (= 0.32.5)
 
 BUNDLED WITH
    2.0.2

--- a/app/graphql/mutations/song_create.rb
+++ b/app/graphql/mutations/song_create.rb
@@ -39,13 +39,11 @@ module Mutations
     end
 
     def attrs_from_youtube!(song)
-      video = Yt::Video.new(id: song.youtube_id)
+      video = YoutubeClient.new(current_user).find(song.youtube_id)
       song.update!(
         description: video.description,
         duration_in_seconds: video.duration,
         name: video.title,
-        license: video.license,
-        licensed: video.licensed?,
         thumbnail_url: video.thumbnail_url,
         youtube_tags: video.tags
       )

--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -188,6 +188,8 @@ module Types
     end
 
     def search(query:, lookahead:)
+      return [] if query.blank?
+
       Selectors::SearchResults
         .new(user: current_user, lookahead: lookahead)
         .search(query: query)

--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -188,6 +188,7 @@ module Types
     end
 
     def search(query:, lookahead:)
+      confirm_current_user!
       return [] if query.blank?
 
       Selectors::SearchResults

--- a/app/graphql/types/search_result_type.rb
+++ b/app/graphql/types/search_result_type.rb
@@ -2,12 +2,10 @@
 
 module Types
   class SearchResultType < Types::BaseUnion
-    possible_types Types::LibraryRecordType, Types::SongType, Types::YoutubeResultType
+    possible_types Types::SongType, Types::YoutubeResultType
 
     def self.resolve_type(object, _context)
       case object
-      when LibraryRecord
-        Types::LibraryRecordType
       when Song
         Types::SongType
       when Yt::Models::Video

--- a/app/graphql/types/search_result_type.rb
+++ b/app/graphql/types/search_result_type.rb
@@ -8,7 +8,7 @@ module Types
       case object
       when Song
         Types::SongType
-      when Yt::Models::Video
+      when OpenStruct
         Types::YoutubeResultType
       end
     end

--- a/app/graphql/types/youtube_result_type.rb
+++ b/app/graphql/types/youtube_result_type.rb
@@ -6,8 +6,7 @@ module Types
 
     field :id, ID, null: false
     field :description, String, null: false
-    field :duration, Integer, null: false
-    field :title, String, null: false
+    field :name, String, null: false
     field :thumbnail_url, String, null: false
   end
 end

--- a/app/lib/selectors/search_results.rb
+++ b/app/lib/selectors/search_results.rb
@@ -9,31 +9,21 @@ module Selectors
     end
 
     def search(query:)
-      library_records = from_library(query)
-      return library_records if library_records.present?
-
       songs = from_all_songs(query)
       return songs if songs.present?
 
-      # youtube_results = from_youtube(query)
-      # return youtube_results if youtube_results.present?
+      youtube_results = from_youtube(query)
+      return youtube_results if youtube_results.present?
 
       []
     end
 
     private
 
-    def from_library(query)
-      Selectors::LibraryRecords
-        .new(lookahead: lookahead, user: user)
-        .for_user
-        .with_query(query)
-        .without_pending_records
-        .library_records
-    end
-
     def from_all_songs(query)
-      Song.where(Song.arel_table[:name].matches("%#{query}%"))
+      Song
+        .where(Song.arel_table[:name].matches("%#{query}%"))
+        .where.not(id: LibraryRecord.select(:song_id).where(user: user))
     end
 
     def from_youtube(query)

--- a/app/lib/selectors/search_results.rb
+++ b/app/lib/selectors/search_results.rb
@@ -27,12 +27,7 @@ module Selectors
     end
 
     def from_youtube(query)
-      Yt::Collections::Videos.new.where(
-        q: query,
-        type: "video",
-        max_results: 4,
-        order: "relevance"
-      )
+      YoutubeClient.new(user).search(query)
     end
   end
 end

--- a/app/lib/youtube_client.rb
+++ b/app/lib/youtube_client.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+class YoutubeClient
+  attr_accessor :user
+  def initialize(user)
+    @user = user
+  end
+
+  def find(youtube_id)
+    params = { part: "snippet,contentDetails", id: youtube_id, key: ENV["YOUTUBE_KEY"] }
+    data = get("https://www.googleapis.com/youtube/v3/videos", params)&.dig(:items, 0)
+    return nil if data.blank?
+
+    OpenStruct.new(
+      description: data.dig(:snippet, :description),
+      duration: ActiveSupport::Duration.parse(data.dig(:contentDetails, :duration)).to_f,
+      title: data.dig(:snippet, :title),
+      thumbnail_url: data.dig(:snippet, :thumbnails, :default, :url),
+      tags: data.dig(:snippet, :tags)
+    )
+  end
+
+  def search(query)
+    params = { part: "snippet", q: query, key: ENV["YOUTUBE_KEY"], type: "video" }
+    data = get("https://www.googleapis.com/youtube/v3/search", params)&.dig(:items)
+    return [] if data.blank?
+
+    data.map do |d|
+      OpenStruct.new(
+        id: d.dig(:id, :videoId),
+        description: d.dig(:snippet, :description),
+        name: d.dig(:snippet, :title),
+        thumbnail_url: d.dig(:snippet, :thumbnails, :default, :url)
+      )
+    end
+  end
+
+  private
+
+  def get(url, params)
+    uri = URI(url)
+    uri.query = URI.encode_www_form(params)
+
+    response = Net::HTTP.start(uri.host, uri.port, use_ssl: true) do |http|
+      request = Net::HTTP::Get.new(uri)
+      request["Accept"] = "application/json"
+
+      http.request(request)
+    end
+
+    return nil unless response.is_a?(Net::HTTPSuccess)
+
+    JSON.parse(response.body, symbolize_names: true)
+  end
+end

--- a/config/initializers/yt.rb
+++ b/config/initializers/yt.rb
@@ -1,5 +1,0 @@
-# frozen_string_literal: true
-
-Yt.configure do |config|
-  config.api_key = ENV["YOUTUBE_KEY"]
-end

--- a/spec/queries/search_spec.rb
+++ b/spec/queries/search_spec.rb
@@ -37,11 +37,15 @@ RSpec.describe "Search Query", type: :request do
   end
 
   it "returns youtube results if no library records or other songs exist" do
-    # This won't result in a network request as long as we only retrieve the 'id'
-    # and no other properties in our graphql call
-    result = Yt::Models::Video.new(id: "youtube-id")
-    video_double = instance_double(Yt::Collections::Videos, where: [result])
-    expect(Yt::Collections::Videos).to receive(:new).and_return(video_double)
+    video = OpenStruct.new(
+      id: "youtube-id",
+      description: "a description",
+      thumbnail_url: "https://i.ytimg.com/vi/bnVUHWCynig/default.jpg",
+      tags: %w[dope chill beatz]
+    )
+    client_double = instance_double(YoutubeClient)
+    expect(client_double).to receive(:search).with("entirely-outside-song").and_return([video])
+    expect(YoutubeClient).to receive(:new).and_return(client_double)
 
     graphql_request(query: query, user: user, variables: { query: "entirely-outside-song" })
 

--- a/spec/queries/search_spec.rb
+++ b/spec/queries/search_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe "Songs Query", type: :request do
+RSpec.describe "Search Query", type: :request do
   include AuthHelper
   include JsonHelper
 
@@ -11,9 +11,6 @@ RSpec.describe "Songs Query", type: :request do
       query Search($query: String!) {
         search(query: $query) {
           __typename
-          ... on LibraryRecord {
-            id
-          }
           ... on Song {
             id
           }
@@ -27,26 +24,19 @@ RSpec.describe "Songs Query", type: :request do
 
   let(:user) { create(:user) }
   let(:library_song) { create(:song, name: "my-song") }
-  let!(:library_record) { create(:library_record, song: library_song, user: user) }
   let!(:other_song) { create(:song, name: "other-song") }
 
-  it "prefers to return library records if any exist" do
+  it "returns songs that do not exist in the user's library" do
+    create(:library_record, song: library_song, user: user)
+
     graphql_request(query: query, user: user, variables: { query: "song" })
-
-    expect(json_body.dig(:data, :search).size).to eq(1)
-    expect(json_body.dig(:data, :search, 0, :__typename)).to eq("LibraryRecord")
-    expect(json_body.dig(:data, :search, 0, :id)).to eq(library_record.id)
-  end
-
-  it "returns songs if no library records exist" do
-    graphql_request(query: query, user: user, variables: { query: "other-song" })
 
     expect(json_body.dig(:data, :search).size).to eq(1)
     expect(json_body.dig(:data, :search, 0, :__typename)).to eq("Song")
     expect(json_body.dig(:data, :search, 0, :id)).to eq(other_song.id)
   end
 
-  xit "returns youtube results if no library records or other songs exist" do
+  it "returns youtube results if no library records or other songs exist" do
     # This won't result in a network request as long as we only retrieve the 'id'
     # and no other properties in our graphql call
     result = Yt::Models::Video.new(id: "youtube-id")


### PR DESCRIPTION
@go-between/folks 

This PR reenables youtube search.  It also:
  - Removes the `yt` gem in favor of a couple of direct calls to youtube (allows us to control quota usage more carefully)
  - Removes user's own library records from the search query