### PR TITLE
Downgrade airbrake to 9x to avoid weird stack level too deep recursiv…

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -29,7 +29,7 @@ gem "doorkeeper", "5.2.5"
 gem "graphiql-rails", "1.7.0"
 gem "graphql", "1.10.10"
 
-gem "airbrake", "10.0.5"
+gem "airbrake", "9.5.5"
 gem "skylight", "4.2.2"
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -58,8 +58,8 @@ GEM
       zeitwerk (~> 2.2, >= 2.2.2)
     addressable (2.7.0)
       public_suffix (>= 2.0.2, < 5.0)
-    airbrake (10.0.5)
-      airbrake-ruby (~> 4.13)
+    airbrake (9.5.5)
+      airbrake-ruby (~> 4.8)
     airbrake-ruby (4.15.0)
       rbtree3 (~> 0.5)
     ast (2.4.1)
@@ -256,7 +256,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  airbrake (= 10.0.5)
+  airbrake (= 9.5.5)
   bullet (= 6.1.0)
   database_cleaner (= 1.7.0)
   devise (= 4.7.1)


### PR DESCRIPTION
@go-between/folks 

Somewhere in the network code of the airbrake gem, we generate an exception when submitting an exception trace.  This causes Airbrake to try to send another trace, which generates another exception.  This causes Airbrake to try to send another trace, which generates another exception.  This causes Airbrake to try to send another trace, which generates another exception.  This causes Airbrake to try to send another trace, which generates another exception.  This causes Airbrake to try to send another trace, which generates another exception.  This causes Airbrake to try to send another trace, which generates another exception.  This causes Airbrake to try to send another trace, which generates another exception.  This causes Airbrake to try to send another trace, which generates another exception.  This causes Airbrake to try to send another trace, which generates another exception.  This causes Airbrake to try to send another trace, which generates another exception.  This causes Airbrake to try to send another trace, which generates another exception.  This causes Airbrake to try to send another trace, which generates another exception.  This causes Airbrake to try to send another trace, which generates another exception.  This causes Airbrake to try to send another trace, which generates another exception.  This causes Airbrake to try to send another trace, which generates another exception.  This causes Airbrake to try to send another trace, which generates another exception.  This causes Airbrake to try to send another trace, which generates another exception.  This causes Airbrake to try to send another trace, which generates another exception.  This causes Airbrake to try to send another trace, which generates another exception.  This causes Airbrake to try to send another trace, which generates another exception.  This causes Airbrake to try to send another trace, which generates another exception.  This causes Airbrake to try to send another trace, which generates another exception.  This causes Airbrake to try to send another trace, which generates another exception.  This causes Airbrake to try to send another trace, which generates another exception.

```
Trumans-MacBook-Pro:musicbox-api trumanshuck$ LOG_LEVEL=debug rake airbrake:test
W, [2020-07-26T21:43:49.379165 #14587]  WARN -- Skylight: [SKYLIGHT] [4.2.2] Running Skylight in development mode. No data will be reported until you deploy your app.
(To disable this message for all local apps, run `skylight disable_dev_warning`.)
rake aborted!
SystemStackError: stack level too deep

Tasks: TOP => airbrake:test
(See full trace by running task with --trace)
```