### PR TITLE
add codebase index at autopilot-support/index

### DIFF
--- a/autopilot-support/index/CLAUDE.md
+++ b/autopilot-support/index/CLAUDE.md
@@ -1,0 +1,58 @@
+# musicbox-api Index
+
+This index is the entry point for navigating the musicbox-api codebase. It is **not** a substitute for reading the code — it is a map that tells you *where to look* and *what is non-obvious*.
+
+musicbox-api is a Rails GraphQL API powering a real-time, social music listening application. Users join teams, gather in rooms, build collaborative playlists from YouTube-backed songs, chat, and watch synchronized playback. The backend is GraphQL-only over a single REST endpoint, with ActionCable channels broadcasting room state to connected clients and Sidekiq workers handling email and broadcast fan-out.
+
+## Index Rules
+
+Every file in this index obeys these rules. Future writers must too.
+
+1. **Point to files, never duplicate code.** Reference paths like `app/models/room.rb`. Never paste code blocks or function bodies into the index.
+2. **No line numbers.** Files churn; line numbers rot. Reference symbols by name (`Room#activate!`), not location.
+3. **Only non-obvious information.** If a reader can learn it in 30 seconds by reading the file, don't write it here. The index records *why*, *where to look*, and *what's surprising* — not *what the code says*.
+4. **Manifest is the entry point.** This file lists every structure and feature file. Anything added to the index must be listed here.
+5. **Three-file feature convention.** Each `features/{slug}/` directory contains exactly three files:
+   - `map.md` — what files comprise this feature and what each does (one line per file, points to path)
+   - `patterns.md` — non-obvious conventions, idioms, and abstractions used by this feature
+   - `boundaries.md` — extension points, "do not build" items, and where this feature ends / another begins
+6. **`feature_classification.csv` is the source of truth for feature scope.** Filter its rows by the `Feature` column to find which files belong to a feature.
+
+## Structures
+
+Cross-cutting views of the codebase, organized by concern rather than by feature.
+
+- [structures/modules.md](structures/modules.md) — How non-MVC code is organized: `app/lib/` plain Ruby services and the `Selectors` namespace, `app/workers/` Sidekiq jobs grouped into `broadcast_*` / `email_*` / standalone, and the single `room:poll_queue` rake task.
+- [structures/data-model.md](structures/data-model.md) — Models, relationships, and surprising fields. UUID PKs throughout; points at `db/structure.sql` (authoritative since commit `8a9a086`) for column-level truth.
+- [structures/resources.md](structures/resources.md) — The single `POST /api/v1/graphql` endpoint, 23 mutations grouped by domain, the `QueryType` resolver, 9 ActionCable channels (auth via Doorkeeper token in WebSocket query string), and the three-layer authorization model.
+- [structures/infrastructure.md](structures/infrastructure.md) — Sidekiq, ActionCable, Redis, Postgres (+ `pgcrypto` + `pg_trgm` extensions), Devise + Doorkeeper (password-grant only, non-expiring tokens), Airbrake, Docker, Render, nginx, Passenger, and Clockwork. Operational details defer to `README.md` and `COSTS.md`.
+- [structures/testing.md](structures/testing.md) — RSpec suite mirrored to the GraphQL-first architecture (no controller/system/view specs). Auth in tests goes through real Doorkeeper tokens via `spec/support/auth_helper.rb`; email workers share `spec/workers/email_worker_shared_examples.rb`; `Sidekiq::Testing.inline!` is per-spec opt-in.
+
+## Features
+
+Each feature directory holds three files (`map.md`, `patterns.md`, `boundaries.md`). The slug below maps to the CSV `Feature` label, with the highest-value non-obvious detail surfaced.
+
+- [features/user-authentication/](features/user-authentication/) — *User Authentication & Management*. Devise + Doorkeeper (password grant only, non-expiring tokens). `current_user` resolved through three separate paths (controller, GraphQL context, ActionCable connection); `User#start_password_reset!` exists to expose Devise's protected token-setter to the password-reset feature.
+- [features/user-invitations/](features/user-invitations/) — *User Invitation System*. Token-based invite flow with direct-HTTP Mailgun delivery; `invited_user` association is email-keyed (works before user exists). `Invitation.token` is a class method; idempotent `find_or_initialize_by(email, team)` is the seam.
+- [features/password-reset/](features/password-reset/) — *Password Reset System*. Devise-managed `reset_password_token` + `reset_password_sent_at`; initiate returns empty errors on unknown email (no enumeration); complete returns a Doorkeeper access token on success.
+- [features/teams/](features/teams/) — *Team Collaboration*. `Team#owner` is an FK on `teams`, not a join. `team_users` membership pinned to the legacy `teams_users` plural-plural table name; `User#active_team_id` carries current-team context.
+- [features/rooms/](features/rooms/) — *Room Management*. Users belong to a room via `users.active_room_id` (not `room_id`). `Room#idle!` and `Room#playing_record!` are the atomic state transitions; `user_rotation` is a `uuid[]` array column for round-robin DJ order.
+- [features/playlist-management/](features/playlist-management/) — *Playlist Management*. `RoomPlaylistRecord` is a Room×Song×User join with `play_state` enum (`waiting`/`played`); `RoomPlaylistGenerator` interleaves by `Room#user_rotation` under `room.with_lock`. Add is append; reorder is destructive replace.
+- [features/queue-management/](features/queue-management/) — *Queue Management*. Clockwork (1Hz) polls via `RoomQueuePoller`, which flips qualifying rooms to `queue_processing: true` with `update_all` before enqueueing `QueueManagementWorker` — the flip is the idempotency lock.
+- [features/real-time-playback/](features/real-time-playback/) — *Real-time Music Playback*. A no-body `NowPlayingChannel` plus one worker that re-runs a GraphQL query and pushes the result. Clients sync via `playedAt + durationInSeconds`; no heartbeat, no server-driven seek.
+- [features/messages/](features/messages/) — *Message & Chat System*. Pin is the `pinned` boolean column on `Message`, not a separate model. Two channels (`MessageChannel`, `PinnedMessagesChannel`) because pinned needs its own stream; both broadcast via GraphQL-shaped payloads.
+- [features/music-library/](features/music-library/) — *User Music Library*. `LibraryRecord` is the user↔song join. `source` enum (`saved_from_history`, `pending_recommendation`, `accepted_recommendation`) carries provenance; `User#library_records` filters out pending recommendations via Arel. Deletion is destructive.
+- [features/songs/](features/songs/) — *Song Library*. `youtube_id` uniqueness is app-enforced (no DB constraint). `SongCreate` hydrates YouTube metadata only on first insert. `Song.search` is a 3-tier OR (tsvector + pg_trgm fuzzy + ILIKE fallback) — but see the search feature for what's actually wired.
+- [features/listening-history/](features/listening-history/) — *Music Listening History*. The `unique_record_listens` index dedups per `(room_playlist_record, song, user)`; `approval` is mutated in place. `RecordListenCreate` gates on `active_room.current_record_id` as a security boundary.
+- [features/music-statistics/](features/music-statistics/) — *Music Statistics*. `Unwound` (live GraphQL resolver) and `MusicboxUnwound` (frozen console script) are parallel implementations, not a wrapper pair. Plays come from `RoomPlaylistRecord`; approvals come from `RecordListen`.
+- [features/tagging/](features/tagging/) — *Music Tagging*. Tags are user-scoped (not global/team). `TagLibraryRecord` joins to `LibraryRecord`, not `Song`; table name pinned to legacy `tags_library_records` plural-plural; uniqueness enforced at the DB index with `insert_all`/`delete_all` skipping callbacks.
+- [features/recommendations/](features/recommendations/) — *Music Recommendation*. No `Recommendation` model — recommendations are `LibraryRecord` rows in `pending_recommendation`/`accepted_recommendation` states. The `recommendations` GraphQL query has two asymmetric modes (inbox vs. song-scoped outbox).
+- [features/search/](features/search/) — *Search Functionality*. The wired GraphQL `search` path uses a plain ILIKE on `songs.name` via `Selectors::SearchResults#from_all_songs` — `Song`'s 3-tier ranked search is implemented but not yet invoked through GraphQL. Flagged as the obvious extension point.
+- [features/youtube/](features/youtube/) — *YouTube Integration*. `YoutubeClient` is raw `Net::HTTP` with no retries, no error handling, no Airbrake integration despite the initializer being configured. Constructor takes a `user` arg it never uses — kept for future per-user OAuth/quota. Hydration is single-shot.
+
+## How to extend this index
+
+- When you add a new structure file, link it under **Structures** above with a one-line summary derived from its H1 + intro.
+- When you add a new feature, create `features/{slug}/{map,patterns,boundaries}.md` and link the directory under **Features** with the CSV `Feature` label and the highest-value non-obvious detail.
+- When a feature's scope shifts, update both the `boundaries.md` of the affected features and the one-line summary here.
+- Run the integrity checks before merging an index change: every linked file must exist; every produced `.md` must be referenced; no `\.rb:N` / `\.sql:N` patterns; no ```ruby / ```rb fences.

--- a/autopilot-support/index/features/listening-history/boundaries.md
+++ b/autopilot-support/index/features/listening-history/boundaries.md
@@ -1,0 +1,22 @@
+# Listening History — Boundaries
+
+## Extension points
+- New per-play context (room, playback source, device) should be added as columns on `record_listens` plus selective inclusion in `Types::RecordListenType`. The unique key is `(room_playlist_record_id, song_id, user_id)` — any new dimension that should split listens (e.g., re-listens within the same record) must extend that index, not just the table.
+- New reaction shapes (beyond the 0–3 `approval` scalar) belong on the existing row, edited in place by `RecordListenCreate`. Add the field, expand `ensure_approval_range`-style clamping in the mutation, and surface it on `Types::RecordListenType`. Do not introduce a sibling table that key-shares with `record_listens`.
+- Additional broadcast triggers (e.g., on delete or on a new event type) should follow the `BroadcastRecordListensWorker` pattern: enqueue from the writing mutation, re-execute the canonical GraphQL query with `override_current_user: true`, broadcast to `RecordListensChannel`. Reuse the queue `broadcast_record_listens` only if the new work has the same priority profile.
+- New subscriber audiences (team dashboards, presence panels) should subscribe to the existing `RecordListensChannel` on the room stream rather than introducing a parallel channel — the empty channel class is intentionally a thin transport.
+
+## Do-not-build
+- Do not aggregate listening stats here. Year-end summaries, top songs, listener vs DJ splits, and any "favorites" computations belong in **music-statistics** (`app/lib/musicbox_unwound.rb`, `app/lib/unwound.rb`). This feature owns the row; statistics owns the query.
+- Do not reuse `RecordListen` as a recommendation signal source from within this feature. Recommendations read whatever upstream signal they need; see **recommendations** for the model and its own write path.
+- Do not allow listens to be created for a record that is not the room's current playing record. The `record_playing?` check is a security/data-integrity boundary — bypassing it would let any user log a listen on any historical record they could name.
+- Do not add per-event play tracking (every press of play, scrubs, partial listens) on this table. The row's semantic is "this user was present for this spin"; finer-grained events should live in a separate domain rather than being squeezed into approval levels or new columns.
+- Do not assume the worker will retry indefinitely on a stale `record_id`. `BroadcastRecordListensWorker` returns silently when the room's current record has moved on; if you need at-least-once delivery for a listen, the storage row itself is the source of truth, not the broadcast.
+- Do not bypass `find_or_create_by!` + `RecordNotUnique` rescue when writing listens. The unique index will reject concurrent creates; the established pattern in `RecordListenCreate#ensure_record_listen!` is the only sanctioned write path.
+
+## Where listening history ends
+- **Music Statistics** (`features/music-statistics/`) owns all reads-for-analytics of `record_listens`. If a question is "how many," "top N," or "over time," it lives there.
+- **Recommendations** (`features/recommendations/`) owns surfacing songs to users. It may consume signals derived from listening history, but the schema, models, and write paths are its own.
+- **Real-time Playback** (`features/real-time-playback/`) owns "what is playing now" via `NowPlayingChannel`. `RecordListensChannel` is adjacent but distinct: it carries the reactions for the currently playing record, not playback state itself.
+- **Playlist Management** (`features/playlist-management/`) owns `RoomPlaylistRecord`. Listening History only points at it; lifecycle (create, reorder, abandon) is not this feature's concern. The `record_listens` `has_many` on `RoomPlaylistRecord` is declared there.
+- **Rooms** (`features/rooms/`) owns `current_record_id` and the `active_room` concept the mutation gates on. Changes to how a room's "current record" is determined ripple here through the gating check.

--- a/autopilot-support/index/features/listening-history/map.md
+++ b/autopilot-support/index/features/listening-history/map.md
@@ -1,0 +1,24 @@
+# Listening History — Map
+
+## Model
+- `app/models/record_listen.rb` — User-song play log; `belongs_to :room_playlist_record, :song, :user`. Schema-level `unique_record_listens` index enforces one row per `(room_playlist_record_id, song_id, user_id)` triple; the `approval` integer is updated in place rather than appending new rows.
+
+## GraphQL
+- `app/graphql/mutations/record_listen_create.rb` — Single write path. Rejects when the supplied `record_id` is not the caller's `active_room.current_record_id`; upserts the listen via `find_or_create_by!` with a `RecordNotUnique` fallback; clamps `approval` to `0..3`; enqueues `BroadcastRecordListensWorker`.
+- `app/graphql/types/record_listen_type.rb` — Exposes `id`, `approval`, `room_playlist_record`, `song`, `user`. No timestamps surfaced.
+
+## Realtime
+- `app/channels/record_listens_channel.rb` — Empty ActionCable channel (no `subscribed`/`unsubscribed` callbacks); transport surface only. Broadcasts are triggered by the worker via `RecordListensChannel.broadcast_to(room, ...)`.
+
+## Workers
+- `app/workers/broadcast_record_listens_worker.rb` — Re-runs the `recordListens` GraphQL query for the room's current record with `override_current_user: true`, then broadcasts the rendered result to the room. Queue: `broadcast_record_listens`.
+
+## Migrations
+- `db/migrate/20200318014102_create_listens_table.rb` — Creates `record_listens` with uuid PK and per-FK indexes on `room_playlist_record_id` and `song_id` only (no `user_id` index).
+- `db/migrate/20200603024043_add_unique_constraint_on_record_listens.rb` — Data migration that destroys all-but-most-recent duplicates per `(room_playlist_record_id, song_id, user_id)` before adding the `unique_record_listens` unique index. `down` raises `IrreversibleMigration`.
+
+## Specs
+- `spec/models/record_listen_spec.rb` — Smoke test that the three `belongs_to` relations round-trip.
+- `spec/mutations/record_listen_create_spec.rb` — Covers create, update-in-place on existing listen, and the `ActiveRecord::RecordNotUnique` fallback path; asserts worker enqueue in every success case.
+- `spec/queries/record_listens_spec.rb` — Exercises the `recordListens(recordId:)` query (resolver lives on `Types::QueryType`, not in this feature's CSV scope).
+- `spec/workers/broadcast_record_listens_worker_spec.rb` — Uses `have_broadcasted_to ... from_channel(RecordListensChannel)` to assert payload shape and per-user approval values.

--- a/autopilot-support/index/features/listening-history/patterns.md
+++ b/autopilot-support/index/features/listening-history/patterns.md
@@ -1,0 +1,22 @@
+# Listening History — Patterns
+
+## What a "listen" actually is
+- A `RecordListen` is not a per-playback event. The `unique_record_listens` index keys on `(room_playlist_record_id, song_id, user_id)` — the dedup window is the lifetime of a single `RoomPlaylistRecord` (one queued spin of a song in a room). Re-listening to the same song in a new queue entry creates a new row; re-rating mid-play updates the existing row in place.
+- `approval` is the user's reaction to that one spin (0–3, clamped in the mutation). It is the only mutable field on the row after create; the row itself is the "did this user hear this record" signal.
+
+## Mutation contract
+- The mutation refuses any `record_id` that is not `current_user.active_room.current_record_id`. You cannot back-fill a listen for a record that has rolled off — listens only accrue for the room's currently playing record. Treat this as the security boundary, not just an input check.
+- `ensure_record_listen!` uses `find_or_create_by!` and explicitly rescues `ActiveRecord::RecordNotUnique` (race between concurrent creates against the `unique_record_listens` index). The spec for that path is the canonical example of how to write race-safe upserts in this codebase against a unique index.
+- `approval` is clamped via `ensure_approval_range` to `0..3`. Clients should not pre-validate; rely on server clamping.
+
+## Broadcast fan-out
+- `BroadcastRecordListensWorker` re-executes the `recordListens` GraphQL query through `MusicboxApiSchema.execute` with `context: { override_current_user: true }`. This is the codebase's idiom for worker-originated GraphQL: there is no logged-in user inside Sidekiq, so the resolver must opt out of `current_user` checks. Look for `override_current_user` in `app/graphql/musicbox_api_schema.rb`/resolvers when extending.
+- The worker looks the room up by `Room.find_by(current_record_id: record_id)` and silently returns if no room currently has that record — so a late-arriving broadcast for a record that has already advanced is dropped, not retried.
+- The broadcast payload is the full `recordListens` query result (with `user { id, email, name }`), shaped for room dashboards rather than for the listening user. `RecordListensChannel` is empty by design — there are no per-subscriber filters; every subscriber to the room channel sees every user's approval.
+
+## Query resolver lives elsewhere
+- The `recordListens(recordId:)` field is defined on `app/graphql/types/query_type.rb` (not classified into this feature in the CSV). The worker depends on that field staying named and shaped as it is — changing the query shape requires updating `BroadcastRecordListensWorker#query` in lockstep.
+- `app/graphql/types/room_playlist_record_type.rb` exposes `record_listens` on the record type as well, and `app/lib/selectors/room_playlist_records.rb` includes `:record_listens` based on lookahead to avoid N+1.
+
+## Seeds Music Statistics
+- `app/lib/musicbox_unwound.rb` and `app/lib/unwound.rb` read `record_listens` directly (joining and grouping on `song_id`, `approval`, and the `(room_playlist_record.user_id != record_listens.user_id)` distinction between DJ and listener) to produce year-end stats. Listening History's job is to keep that table truthful; aggregation lives in **music-statistics**.

--- a/autopilot-support/index/features/messages/boundaries.md
+++ b/autopilot-support/index/features/messages/boundaries.md
@@ -1,0 +1,24 @@
+# Message & Chat System — Boundaries
+
+## Extension points
+- New message metadata (reactions, edited-at, soft delete, attachment refs) should be added as columns on `messages` plus a new field on `Types::MessageType` and, if relevant to either broadcast, threaded into the worker's GraphQL document. The broadcast payload is whatever the worker's query asks for — fields not requested there will not reach the client even if they exist on the model.
+- New attachment-style associations (e.g. an uploaded media record) should attach to `Message` via a new optional `belongs_to`, follow the `song`/`room_playlist_record` pattern (nullable, snapshotted at create time in `MessageCreate#create_message!`), and be added to the `record_context` lookahead map in `Selectors::Messages` so they eager-load on demand.
+- New pin metadata (who pinned, pinned_at, pin reason) should be added as columns on `messages` alongside `pinned`. `BroadcastPinnedMessagesWorker`'s GraphQL document and the pinned-messages spec are where to thread them in.
+- New query slices (e.g. "messages by user", "messages since I last read", "search within a room") should be added as additional chainable methods on `Selectors::Messages`, not as standalone scopes on `Message` or inline `where`s in `QueryType`.
+- New broadcast targets (e.g. typing indicators, read receipts) should follow the broadcast-via-GraphQL worker convention — re-execute a fixed query with `override_current_user: true` and `broadcast_to(Room.find(room_id))` — and live as a new channel/worker pair.
+
+## Do-not-build
+- Do not introduce a separate `PinnedMessage` model, a `pinned_messages` table, or a join table for pinning. Pinning is a column on `messages` by design, and the pinned channel reads from the same rows.
+- Do not bypass the broadcast workers. Mutations enqueue, workers render via GraphQL, channels deliver. Calling `MessageChannel.broadcast_to` directly from a mutation or model callback skips the GraphQL-shaped payload contract that all current clients depend on.
+- Do not query `Message` directly from `QueryType`. Go through `Selectors::Messages` so lookahead-driven `includes` keep working.
+- Do not "fix" `Query#pinned_messages` to require either a `current_user` or a `room_id` exclusively — the asymmetry exists so `BroadcastPinnedMessagesWorker` can call it with `override_current_user: true`. Read the inline comment before refactoring.
+- Do not add cross-room message visibility. Active-room scoping is a feature, not an oversight; `MessageCreate` and `Query#messages` both enforce it.
+- Do not let non-authors toggle pins. `MessagePin` deliberately restricts `pinned` writes to the message's own user; admin/moderator overrides are not a feature here.
+- Do not rely on DB-level integrity. The migrations don't define FKs or null constraints on `room_id`/`user_id`/`song_id` — model-layer `belongs_to` is the only enforcement.
+
+## Where messages end
+- `Room` ownership, `active_room` resolution, and per-room broadcasting infrastructure belong to **rooms** (`features/rooms/`). Messages reference rooms but do not own them.
+- `Song` modeling and the `room_playlist_record` join belong to **songs** (`features/songs/`) and **playlist-management** (`features/playlist-management/`); messages snapshot these references at send time but neither creates nor mutates them.
+- `User` identity, `active_room` assignment, and channel-level auth (`ApplicationCable::Connection`) belong to **user-authentication** (`features/user-authentication/`). The empty channel classes here inherit that auth wholesale.
+- The broadcast-via-GraphQL worker convention and `MusicboxApiSchema.execute` plumbing are cross-feature infrastructure (see `structures/infrastructure.md` and the other `Broadcast*Worker` siblings). Changes to that pattern affect every channel-broadcasting feature, not just chat.
+- Notification / unread-state semantics are not implemented anywhere in this feature; if added, they should live alongside `User` state (read cursors) and `Selectors::Messages` filters, not as a new sibling model under messages.

--- a/autopilot-support/index/features/messages/map.md
+++ b/autopilot-support/index/features/messages/map.md
@@ -1,0 +1,36 @@
+# Message & Chat System — Map
+
+## Model
+- `app/models/message.rb` — chat record; `belongs_to :room` (required), `belongs_to :user` (required), and optional `room_playlist_record` and `song`. Pin state is the `pinned` boolean column on this same row — there is no separate model.
+
+## GraphQL
+- `app/graphql/types/message_type.rb` — exposes `id`, `message`, `pinned`, `createdAt`, plus the four associations. `room` and `user` are non-null; `song` and `roomPlaylistRecord` are nullable to allow messages sent outside a playing track.
+- `app/graphql/mutations/message_create.rb` — sends a message in the caller's `active_room`; auto-stamps `room_playlist_record` and `song` from the room's `current_record`. Enqueues `BroadcastMessageWorker`. Refuses if the user has no active room.
+- `app/graphql/mutations/message_pin.rb` — toggles `pinned` on a message owned by `current_user`; enqueues `BroadcastPinnedMessagesWorker` regardless of whether the value actually changed (the noop cases are intentional — see patterns). Returns the error string `"Message must belong to the current user"` when ownership fails.
+- Query wiring lives in `app/graphql/types/query_type.rb` (`messages` and `pinned_messages` fields, both with `extras: [:lookahead]`); see patterns for why `pinned_messages` accepts an optional `room_id`.
+
+## Selectors
+- `app/lib/selectors/messages.rb` — chainable `Selectors::Messages` builder with `for_room_id`, `in_date_range(to:, from:)`, and `when_pinned_to(song_id:)`; `record_context` drives lookahead-aware `includes` so association columns are eager-loaded only when the GraphQL selection asks for them.
+
+## Channels
+- `app/channels/message_channel.rb` — empty subclass of `ApplicationCable::Channel`; auth/streaming is owned by `ApplicationCable::Connection` (see `features/user-authentication/`). Streams per-room, fed by `BroadcastMessageWorker`.
+- `app/channels/pinned_messages_channel.rb` — second empty channel for the pinned-messages stream; co-exists with `MessageChannel` rather than reusing it.
+
+## Workers
+- `app/workers/broadcast_message_worker.rb` — Sidekiq worker on the `broadcast_message` queue; re-executes a fixed GraphQL document against `MusicboxApiSchema` with `override_current_user: true` and broadcasts the result to `MessageChannel.broadcast_to(Room.find(room_id))`. Used for "new message arrived" fan-out.
+- `app/workers/broadcast_pinned_messages_worker.rb` — Sidekiq worker on the `broadcast_pinned_messages` queue; broadcasts the full pinned set for `(room_id, song_id)` to `PinnedMessagesChannel`. Note the worker passes `roomId` but the GraphQL document declares it as `ID` (nullable); the query exists to be reachable both from authenticated callers and from this worker (see patterns).
+
+## Migrations
+- `db/migrate/20200125023143_create_messages.rb` — original `messages` table; UUID primary key, only `room_id` and `created_at` get indexes. No FKs are defined at the DB level.
+- `db/migrate/20200305230807_add_pinned_to_messages.rb` — adds the `pinned` boolean (default `false`) directly onto `messages`; pinning was always a column, never a separate table.
+- `db/migrate/20200307232816_add_song_id_to_message.rb` — adds nullable `song_id` so messages can be associated with whatever was playing when they were sent. No index added.
+
+## Specs
+- `spec/factories/message.rb` — defaults `pinned: false`, `room` and `user` created, but `room_playlist_record` and `song` are `nil`; pass them explicitly when exercising the "pinned to a song" path.
+- `spec/models/message_spec.rb` — pins down that all four belongs_to associations work and that `room_playlist_record` is genuinely optional.
+- `spec/mutations/message_create_spec.rb` — covers the active-room success path, the `BroadcastMessageWorker` enqueue, and the no-active-room refusal.
+- `spec/mutations/message_pin_spec.rb` — exercises all four pin/unpin combinations (including noops), and asserts the broadcast worker is enqueued for each, plus the cross-user failure path.
+- `spec/queries/messages_spec.rb` — locks in `active_room` scoping, ascending `created_at` order, and `from`/`to` filtering semantics.
+- `spec/queries/pinned_messages_spec.rb` — locks in scoping to `(room_id, song_id)` with `pinned: true` only.
+- `spec/workers/broadcast_message_worker_spec.rb` — uses `have_broadcasted_to(room).from_channel(MessageChannel)` and asserts the GraphQL payload shape (camelCased fields, `iso8601` timestamps).
+- `spec/workers/broadcast_pinned_messages_worker_spec.rb` — same broadcast pattern, asserts the full pinned set is sent and that unpinned messages are excluded.

--- a/autopilot-support/index/features/messages/patterns.md
+++ b/autopilot-support/index/features/messages/patterns.md
@@ -1,0 +1,29 @@
+# Message & Chat System — Patterns
+
+## Shape of a Message
+- A `Message` always belongs to a `Room` and a `User`. The `room_playlist_record` and `song` associations are optional — they reflect "what was playing when this was said," not message structure. `MessageCreate` snapshots them from `current_user.active_room.current_record` at send time, so a message stays attached to the song that was playing then, even after the room moves on.
+- Pinning is a `pinned` boolean column on `messages`. Do not introduce a `PinnedMessage` model; see `boundaries.md`. The same row participates in both the chat stream and the pinned stream.
+
+## Two channels, one model
+- `MessageChannel` and `PinnedMessagesChannel` are intentionally separate empty subclasses of `ApplicationCable::Channel`. Clients subscribe to whichever stream they care about; pinned-message updates would otherwise clobber the chat feed with full-set rebroadcasts (the pinned worker sends the whole pinned set, not a delta).
+- Both channels stream per-room via `broadcast_to(Room.find(room_id))`. Auth is inherited from `ApplicationCable::Connection` (see `features/user-authentication/`); the channel classes themselves carry no logic.
+
+## Broadcast-via-GraphQL workers
+- Both broadcast workers render their payload by re-executing a `MusicboxApiSchema.execute(...)` against a hard-coded GraphQL document with `context: { override_current_user: true }`. This is the convention across the codebase's broadcast workers: render through the GraphQL surface so on-the-wire shape matches a normal query response, and skip user auth via the `override_current_user` flag.
+- `BroadcastPinnedMessagesWorker` is the documented reason `Query#pinned_messages` accepts an optional `room_id` and tolerates a missing `current_user` — the comment in `app/graphql/types/query_type.rb` calls this out explicitly ("we're calling this with a current_user and no room_id. Except the broadcast worker which is calling with the opposite"). Authenticated clients pass no `room_id` and the field resolves to their `active_room`; the worker passes `room_id` and no user. Do not "clean this up" without rewiring the worker.
+
+## Pin mutation is fan-out-on-every-call
+- `MessagePin` enqueues `BroadcastPinnedMessagesWorker` on every successful resolve, including the no-state-change noop cases (pin-when-already-pinned, unpin-when-already-unpinned). The pin spec asserts this explicitly. The pinned-messages channel is treated as eventually-consistent; rebroadcasting on noops is the chosen way to repair drifted clients.
+- `MessagePin` only allows the message's own author to toggle the pin (`Message.find_by(user: current_user, id: ...)`). There is no admin or room-owner override.
+
+## Selector composition + lookahead
+- `Selectors::Messages` is the only sanctioned way to query messages. It is intentionally chainable (`for_room_id(...).in_date_range(...).when_pinned_to(...).messages`) and `messages` is the terminal `order(created_at: :asc)` call.
+- `record_context(lookahead)` inspects the GraphQL `lookahead` to decide which of `:room`, `:room_playlist_record`, `:song`, `:user` to `includes`. Keeping new associations out of this map will cause N+1 on the GraphQL surface even if the data is technically reachable.
+- The selector is built with `Message.arel_table` (`@arel`) only because the date-range comparisons use `arel[:created_at].lteq/gteq` to keep nil-aware filtering tidy; other comparisons use plain `where`.
+
+## Active-room is the chat scope
+- `Query#messages` returns `[]` when there is no `active_room` and otherwise hard-scopes to `current_user.active_room_id`. There is no way to fetch messages for a room you're not currently sitting in. Same constraint is baked into `MessageCreate` (refuses if `active_room_id` is blank).
+- "Active room" is owned by the **user-authentication** / **rooms** features (`User#active_room`). The chat feature consumes it; it does not define it.
+
+## Schema-level looseness
+- `messages` has only `room_id` and `created_at` indexes, no FK constraints, no `null: false` constraints on `room_id`/`user_id`. Integrity is enforced at the Rails layer via the model's `belongs_to`. Bulk inserts that skip ActiveRecord will not be caught by the DB.

--- a/autopilot-support/index/features/music-library/boundaries.md
+++ b/autopilot-support/index/features/music-library/boundaries.md
@@ -1,0 +1,24 @@
+# User Music Library — Boundaries
+
+## Extension points
+- New provenance values plug into the `source` enum on `LibraryRecord`. Add the value, add (or extend) a filter on `Selectors::LibraryRecords`, and decide whether `User#library_records` should hide it by default — that lambda is the single place that controls "what counts as the user's library".
+- New filter scopes follow the `with_*` / `without_*` chainable shape on `Selectors::LibraryRecords` (return `self`, mutate `@library_records`). Pair each with a request-level spec in `spec/queries/library_records_spec.rb`.
+- New sortable fields must be real columns on `library_records` or on an existing association class — the selector's `order_by_field` / `order_by_relation` deliberately reject anything else. Adding a derived sort means adding an explicit branch, not loosening the guard.
+- New eager-loaded associations require both a field on `LibraryRecordType` and a matching `*_context!` branch in `record_context` so lookahead remains the single source of preload truth.
+- Additional per-record metadata (e.g., richer recommendation context) belongs as columns on `library_records` alongside `source` / `from_user_id`, not on a sibling table.
+
+## Do-not-build
+- Do not bake recommendation acceptance into this feature. The pending → accepted transition belongs to **recommendations**; this feature only stores the resulting `source` value and provides the filter that hides pendings.
+- Do not store song metadata (name, channel, duration, YouTube id) on `LibraryRecord`. `Song` owns that; duplicating it here defeats the whole reason this is a join table.
+- Do not add soft-delete. `LibraryRecordDelete` is intentionally destructive — adding a `deleted_at` column would silently break the `User#library_records` filter contract and the `pending_recommendation` semantics.
+- Do not introduce a `LibraryRecordCreate` mutation. Creation is owned by the originating feature (history promotion, recommendation acceptance, manual save from search). A generic create mutation would let clients bypass those flows' invariants.
+- Do not hand-roll the pending filter in callers. Either go through `User#library_records` (already filtered) or chain `Selectors::LibraryRecords#without_pending_records`. Re-implementing the `IS NULL OR <>` clause is a known footgun (see `patterns.md`).
+- Do not call `Song.search` from inside the selector without `reorder("")`. The selector relies on stripping Song's ORDER BY to keep `DISTINCT` valid; preserving it produces silent SQL errors.
+
+## Where music-library ends
+- **songs** owns `Song` itself, YouTube linkage, and song-level full-text search infrastructure. This feature consumes `Song.search` but does not define it.
+- **recommendations** owns the create/accept lifecycle for `pending_recommendation` and `accepted_recommendation` rows. This feature is the storage and read path.
+- **tagging** owns `Tag` and `TagLibraryRecord`. The `tags` field on `LibraryRecordType` and the `with_tags` selector method are the integration seam — anything tag-creation related lives there.
+- **listening-history** owns `RecordListen` and the promotion path that mints `saved_from_history` records.
+- **search** owns the `SearchResult` type and pgtrgm tuning; this feature uses search only as a filter input on `libraryRecords`.
+- **user-authentication** owns `current_user` resolution that `LibraryRecordDelete` and the selector rely on.

--- a/autopilot-support/index/features/music-library/map.md
+++ b/autopilot-support/index/features/music-library/map.md
@@ -1,0 +1,26 @@
+# User Music Library — Map
+
+## Model
+- `app/models/library_record.rb` — The user↔song join row with `source` enum (`saved_from_history`, `pending_recommendation`, `accepted_recommendation`), optional `from_user` (recommender), and `has_many :tags` through `tag_library_records`.
+
+## GraphQL
+- `app/graphql/types/library_record_type.rb` — Read shape exposed to clients: `source`, `from_user`, `song`, `user`, `tags`. No mutation fields (creation happens via sibling features).
+- `app/graphql/mutations/library_record_delete.rb` — Only mutation owned by this feature. Scopes lookup to `current_user`, returns `"Can't find song to delete"` on miss, hard-`destroy!`s on success.
+
+## Selector
+- `app/lib/selectors/library_records.rb` — Chainable query builder. `.for_user`, `.without_pending_records`, `.with_query`, `.with_tags` compose with optional `order:`; lookahead drives `includes` to avoid N+1.
+
+## Migrations (table-rename trail)
+- `db/migrate/20190319133140_create_join_table_user_song.rb` — Initial `songs_users` join table, `(user_id, song_id)` only.
+- `db/migrate/20190702133426_add_id_to_songs_users.rb` — Drops & recreates `songs_users` with UUID `id` + timestamps; upgrades it from join table to a real model.
+- `db/migrate/20190927232709_rename_songs_users.rb` — `songs_users` → `user_library_songs`.
+- `db/migrate/20190927234716_rename_user_library_songs.rb` — `user_library_songs` → `user_library_records`.
+- `db/migrate/20200424153153_add_source_data_to_user_library_records.rb` — Adds `from_user_id` and `source` columns; introduces recommendation provenance.
+- `db/migrate/20200513033849_rename_user_library_records.rb` — `user_library_records` → `library_records` (current name).
+- `db/migrate/20200515034314_add_library_record_indexes.rb` — Indexes `created_at` and `source` (selector's default order + pending filter).
+
+## Specs
+- `spec/factories/library_record.rb` — Factory; `source` defaults to `nil` (a plain saved record).
+- `spec/models/library_record_spec.rb` — Smoke coverage of `song`/`user`/`tags` relationships.
+- `spec/mutations/library_record_delete_spec.rb` — Confirms cross-user delete is blocked via the `current_user` scope.
+- `spec/queries/library_records_spec.rb` — Exercises the selector end-to-end: pending exclusion, song-name search, tag filter, combined query+tag, default and song-name ordering, SQL-injection guard on `order.field`.

--- a/autopilot-support/index/features/music-library/patterns.md
+++ b/autopilot-support/index/features/music-library/patterns.md
@@ -1,0 +1,28 @@
+# User Music Library — Patterns
+
+## LibraryRecord is the user↔song join, not a wrapper
+- `LibraryRecord` exists only to materialize the many-to-many between `User` and `Song` with row-level metadata (`source`, `from_user`, `tags`). Song attributes are never duplicated here — always traverse `library_record.song`.
+- The table has been renamed three times (see the migration trail in `map.md`): `songs_users` → `user_library_songs` → `user_library_records` → `library_records`. Old branches, dumps, or external scripts may reference the older names; only `library_records` is current.
+
+## `source` enum encodes recommendation provenance
+- `source` is `nil` for organically saved records, `saved_from_history` when promoted from `RecordListen`, and `pending_recommendation` / `accepted_recommendation` when the row originated from the recommendation feature. `from_user_id` carries the recommender.
+- Treat the recommendation lifecycle as owned by **recommendations**; this feature only stores the resulting state and filters on it.
+
+## `pending_recommendation` is filtered out at the association
+- `User#library_records` in `app/models/user.rb` defines the association with a default `where` that excludes `source = "pending_recommendation"`. It uses an explicit `or(source IS NULL)` because Postgres `<>` drops NULL rows — drop that clause and unsourced records silently disappear.
+- Consequence: `user.library_records`, `user.songs`, and anything that flows through the association already hides pending recs. Code that needs to see them must query `LibraryRecord` directly (e.g., the recommendation acceptance flow).
+
+## Selector composition, not scopes
+- `Selectors::LibraryRecords` is the canonical query path. It is built around mutable `@library_records` state where each chain method returns `self`. `library_records(order:)` is the terminal call.
+- `without_pending_records` exists on the selector even though `User#library_records` already excludes them — it's there for callers that start from `LibraryRecord` directly and need the same guard.
+- `with_query` joins `songs` and merges `Song.search(query)` with `reorder("")` stripped; ordering is then re-applied at the `library_records` level via `apply_song_search_order` to coexist with `DISTINCT`. Do not call `Song.search` here without that reorder strip.
+- `order_by_field` and `order_by_relation` both validate against `column_names` and an allow-list of associations — this is the SQL-injection guard exercised by the `"DROP TABLE"` spec. New sortable fields must remain real columns; arbitrary expressions are rejected by design.
+- `record_context(lookahead)` uses GraphQL lookahead to add `includes(:from_user | :tags | :song | :user)` only when the client selected them. Adding a new association on `LibraryRecordType` means adding a matching `*_context!` branch.
+
+## Deletion is destructive
+- `LibraryRecordDelete` calls `record.destroy!` — there is no soft-delete column, no archival, no tombstone. Tags attached via `tag_library_records` ride along through `dependent` semantics on the join (see tagging feature).
+- The lookup `LibraryRecord.find_by(id:, user: context[:current_user])` is the only authorization check; the error string `"Can't find song to delete"` is asserted by spec and is the contract.
+
+## What this feature does not own
+- Creation of records is split across siblings: history promotion lives in **listening-history**, recommendation acceptance in **recommendations**, manual saves in **songs**/**search** flows. There is intentionally no `LibraryRecordCreate` mutation.
+- The `libraryRecords` query field is wired in the GraphQL query type (see `structures/resources.md`); the selector is what this feature owns, not the resolver registration.

--- a/autopilot-support/index/features/music-statistics/boundaries.md
+++ b/autopilot-support/index/features/music-statistics/boundaries.md
@@ -1,0 +1,23 @@
+# Music Statistics — Boundaries
+
+## Extension points
+- New aggregation methods belong on `app/lib/unwound.rb`. The convention is: add a private `*_in_period` or grouped scope on `plays_in_period`/`record_listens_in_period`, expose a public method that returns `UnwoundCount`-shaped hashes, add the key to the `#call` hash, and add the matching field to `app/graphql/types/unwound_type.rb`. Field name and hash key must agree — the GraphQL layer relies on the hash shape, not on explicit resolvers.
+- New time windows (e.g. month, quarter, custom range) plug in at `period_start`/`period_end`/`start_day` and the `plays_over_time` branch. Keep the year-vs-week branch closed under a single `week.present?` check — don't sprinkle period logic across aggregation methods.
+- New bucket granularities (hour-of-day, day-of-month) should extend `plays_over_time` with a new branch and a new `DATE_PART` group. The contiguous zero-fill pattern (iterate the full bucket range, look up each bucket, default to zero) is the contract clients expect — preserve it.
+- New filters (genre, tag, source room) belong as additional `.where` clauses inside `plays_in_period`/`record_listens_in_period` so every aggregation picks them up uniformly.
+- For a new GraphQL argument, extend both the `field :unwound` argument list in `app/graphql/types/query_type.rb` and the `Unwound#initialize` signature; the resolver passes args through by keyword.
+
+## Do-not-build
+- Do not record new plays or listens inside this feature. Play creation is owned by **playlist-management** (`RoomPlaylistRecord`) and listen logging is owned by **listening-history** (`RecordListen`). Stats are strictly read-side.
+- Do not add denormalized stat columns to `RecordListen`, `RoomPlaylistRecord`, `Song`, or `User` (e.g. `play_count`, `total_approval`). All totals here are computed on read; introducing cached counters would couple write-path features to this feature's aggregation shape.
+- Do not bypass the `invalid_songs` (>= 90 min) filter. If a new aggregation legitimately needs different filtering, factor the filter into a method on `Unwound` rather than inlining a contradictory rule.
+- Do not extend `app/lib/musicbox_unwound.rb` for new features. It is a frozen console-only artifact (hardcoded team name, STDOUT output, no GraphQL surface). New work goes in `Unwound`.
+- Do not add resolvers to `UnwoundType`/`UnwoundCountType`/`UnwoundCountPerWeekType`. These types are pure data shapes whose values come from the `Unwound#call` hash; adding resolver logic would split the aggregation across two layers.
+- Do not introduce a selector under `app/lib/selectors/` for stats. The existing selectors (`library_records`, `messages`, `room_playlist_records`, `search_results`) are chainable read APIs for feature-owned models; `Unwound` is a one-shot report builder and intentionally lives outside that pattern.
+
+## Where music-statistics ends
+- Raw play events (`RoomPlaylistRecord` creation/lifecycle, broadcasting plays) are owned by **playlist-management** / **real-time-playback**. This feature only reads from `room_playlist_records`.
+- Raw approval/listen events (`RecordListen` creation, the approval mutation) are owned by **listening-history**. This feature only reads from `record_listens`.
+- Song metadata (name, `duration_in_seconds`, YouTube linkage) is owned by **songs**. The duration-based outlier filter is a *consumer* of that field, not a definition of it.
+- Team membership resolution (`team.users`, `User.find`) is owned by **teams** / **user-authentication**. `Unwound#users`/`#team` are thin lookups, not the source of truth.
+- No mutations live here. If a future need for "snapshot this report" or "export this stats payload" appears, that mutation belongs in a new sibling feature (e.g. reports/exports), not under music-statistics.

--- a/autopilot-support/index/features/music-statistics/map.md
+++ b/autopilot-support/index/features/music-statistics/map.md
@@ -1,0 +1,13 @@
+# Music Statistics — Map
+
+## GraphQL query entry
+- `app/graphql/types/query_type.rb` — Defines the `unwound` root field and resolver (arguments: `year`, `team_id`, `user_id?`, `week?`, `song_name?`). The resolver instantiates `Unwound` and returns its `#call` hash; no auth gate is applied at the field level beyond what the schema enforces globally.
+
+## GraphQL response shapes
+- `app/graphql/types/unwound_type.rb` — Top-level return type. Seven fields, all non-null arrays, exposing both totals (`team_plays`, `top_plays`, `top_approvals`, `team_approvals`, `song_plays`) and time-series (`top_plays_over_time`, `song_plays_over_time`). Field names match the `Unwound#call` hash keys 1:1 — keep them in lockstep.
+- `app/graphql/types/unwound_count_type.rb` — Repeated row shape `{ label, count, length }` used for every totals list. `length` is "duration in seconds" for play lists, but is overloaded as "approval received" inside `team_approvals` rows.
+- `app/graphql/types/unwound_count_per_week_type.rb` — Wraps a `label` (song name) with `plays: [UnwoundCount]`. The inner `UnwoundCount` rows' `label` is a bucket index (cweek number when year-scoped, day-of-week 0..6 when week-scoped).
+
+## Aggregation services
+- `app/lib/unwound.rb` — The library object behind the GraphQL `unwound` query. PORO that owns all aggregation SQL: groups `RoomPlaylistRecord` by user/song, `RecordListen` by `approval`, and emits `UnwoundCount`-shaped hashes. Switches between weekly buckets (`DATE_PART('week', ...)`) and daily buckets (`DATE_PART('dow', ...)`) based on whether `week` was provided.
+- `app/lib/musicbox_unwound.rb` — Standalone year-end "wrapped"-style report. Not wired into GraphQL; prints `Terminal::Table` output to STDOUT for ad-hoc/console use. Hardcodes the team name "Plug Dot DJ Expats" and iterates back through past years until it runs out of plays.

--- a/autopilot-support/index/features/music-statistics/patterns.md
+++ b/autopilot-support/index/features/music-statistics/patterns.md
@@ -1,0 +1,25 @@
+# Music Statistics — Patterns
+
+## "Unwound" naming
+- The feature is named after Spotify-Wrapped-style "unwinding" of play history — buckets of plays/approvals rolled out across a year or week. The GraphQL type, the service object, and the console script all share the prefix; treat `Unwound*` as a stable namespace, not a coincidence.
+- `MusicboxUnwound` and `Unwound` are not a wrapper pair — they are two separate implementations of the same idea (year-end rollups). `Unwound` is the live GraphQL-backed version with full parameterization (year/team/user/week/song). `MusicboxUnwound` predates it as a CLI/console-only sketch, hardcodes the team, and emits `Terminal::Table` text. New aggregations belong in `Unwound`; treat `MusicboxUnwound` as legacy/example code.
+
+## Plays vs listens — two data sources
+- `RoomPlaylistRecord` is the source of truth for "a song was played in a room" (the DJ event). Anything counting *plays* (`team_plays`, `top_plays`, `top_plays_over_time`, `song_plays*`) groups over `room_playlist_records`.
+- `RecordListen` (see `app/models/record_listen.rb`) is one row per listener-per-play and carries the `approval` integer. Anything counting *approvals* (`team_approvals`, `top_approvals`) groups over `record_listens`. Both are filtered to the same period and the same team's users.
+- `team_approvals` is the only field that joins both sources in one method: it computes approvals *given* from `RecordListen` and approvals *received* by joining `RoomPlaylistRecord` to its `record_listens` (excluding self-approvals via `room_playlist_records.user_id != record_listens.user_id`).
+
+## Period and bucket selection
+- `Unwound#period_start`/`#period_end` collapse the year-vs-week mode behind one query interface. If `week` is present, the period is one ISO week (`beginning_of_week`..`end_of_week`); otherwise it's a full year.
+- Bucketing inside `plays_over_time` switches on the same `week` arg: year mode emits 1..`period_end.cweek` rows labeled by ISO week number; week mode emits 0..6 rows labeled by day-of-week. The empty-bucket fill (zero-filling missing weeks/days) is intentional so the client sees a contiguous series.
+- `start_day` walks forward day-by-day from Jan 1 until it lands in ISO week 1 — needed because Jan 1 is not always in cweek 1 (leap-year/weekday drift). Don't replace this with `Date#cweek` arithmetic without understanding that edge case.
+
+## Result-row shape overloading
+- Every list field returns `UnwoundCount` rows (`{ label, count, length }`), but the meaning of `length` varies: it's `sum(songs.duration_in_seconds)` for `team_plays`/`song_plays`, `approval_received` for `team_approvals`, and a literal `0` (placeholder) for `top_plays`/`top_approvals`/`plays_over_time` rows. Don't assume `length` is duration without checking the producing method.
+- `label` is similarly polymorphic: user name for `team_*`, song name for `top_*` and `song_*`, and a week/day index string for the inner `plays_over_time` rows.
+
+## Outlier filter
+- Both `Unwound` and `MusicboxUnwound` exclude songs with `duration_in_seconds >= 90 minutes` via `invalid_songs`. This is the project's standing filter for "this isn't a song, it's a mix/podcast" — apply the same filter to any new aggregation here.
+
+## User scoping
+- `Unwound#users` defaults to the whole team, but collapses to a single-user array when `user_id` is provided. Every aggregation uses `where(user: users)` so the same code path serves both team-wide and per-user reports.

--- a/autopilot-support/index/features/password-reset/boundaries.md
+++ b/autopilot-support/index/features/password-reset/boundaries.md
@@ -1,0 +1,19 @@
+# Password Reset — Boundaries
+
+## Extension points
+- New delivery channels (SMS, in-app, alternate ESP) plug in by adding a sibling worker to `app/workers/email_password_reset_worker.rb` and dispatching from `PasswordResetInitiate#send_password_reset_email!`. Keep the `(user_id, raw_token)` handoff shape so the token never has to be regenerated.
+- Token format changes (length, encoding, single-use semantics) should be made by overriding Devise's reset helpers on `User`, not by introducing parallel token columns. `User#start_password_reset!` is the seam.
+- Reset window tuning is a one-line change in `config/initializers/devise.rb` (`reset_password_within`); the complete mutation and its spec pick it up automatically.
+- New failure reasons should be added as additional string entries in the `errors` array on `PasswordResetComplete` to keep the response shape stable.
+
+## Do-not-build
+- Do not bypass Devise's reset infrastructure. No custom `reset_password_token` columns, no hand-rolled digest comparisons, no manual `reset_password_sent_at` writes outside Devise — `with_reset_password_token` and `reset_password_period_valid?` are the only sanctioned lookups/validators.
+- Do not return different responses from `PasswordResetInitiate` based on whether the email exists. Account enumeration is intentionally blocked here.
+- Do not move password validation logic into the mutation; rely on `user.reset_password(...)` so password policies stay centralized on the `User` model.
+- Do not have the worker re-derive or re-issue tokens. The raw token only exists at initiate time; the worker is a pure carrier.
+
+## Where password-reset ends
+- The `User` model and its Devise configuration (database_authenticatable, recoverable, validatable) belong to **user-authentication**. This feature consumes Devise's recoverable surface but does not own it.
+- Normal authenticated password changes (profile-driven updates) live with **user-authentication**, not here. This feature is strictly the forgot-password / out-of-session path.
+- Access token issuance (`access_token_for`, Doorkeeper integration) is owned by **user-authentication**; the complete mutation calls into it but should not grow Doorkeeper knowledge of its own.
+- The Mailgun HTTP plumbing pattern and `"a mailgun worker"` shared example are cross-feature infrastructure; changes there affect every transactional email worker, not just password reset.

--- a/autopilot-support/index/features/password-reset/map.md
+++ b/autopilot-support/index/features/password-reset/map.md
@@ -1,0 +1,13 @@
+# Password Reset — Map
+
+## GraphQL Mutations
+- `app/graphql/mutations/password_reset_initiate.rb` — accepts email, looks up user, generates reset token via `User#start_password_reset!`, enqueues delivery worker. Returns empty errors even on unknown email (no enumeration).
+- `app/graphql/mutations/password_reset_complete.rb` — accepts email + token + new password, validates token, checks Devise reset window, applies new password, returns a Doorkeeper access token on success.
+
+## Workers
+- `app/workers/email_password_reset_worker.rb` — Sidekiq worker on the `email_password_resets` queue; posts to Mailgun using the `password-reset` template with `name`, `token`, and url-encoded `email` template variables.
+
+## Specs
+- `spec/mutations/password_reset_initiate_spec.rb` — request-level coverage for enqueue on hit and silent no-op on unknown email.
+- `spec/mutations/password_reset_complete_spec.rb` — success + four error cases (invalid token, mismatched email, expired token, weak password); documents the six-hour reset window.
+- `spec/workers/email_password_reset_worker_spec.rb` — exercises the worker via the `a mailgun worker` shared example with the expected Mailgun payload.

--- a/autopilot-support/index/features/password-reset/patterns.md
+++ b/autopilot-support/index/features/password-reset/patterns.md
@@ -1,0 +1,22 @@
+# Password Reset — Patterns
+
+## Devise-managed token state
+- Token storage and lifecycle live on `User` via Devise `:recoverable` (see `app/models/user.rb`): `reset_password_token` and `reset_password_sent_at` columns are written by Devise, not by app code.
+- Token generation is wrapped in `User#start_password_reset!`, which delegates to Devise's `set_reset_password_token` and returns the raw token (the DB stores a digest, not the raw value).
+- Lookup in the complete mutation uses `User.with_reset_password_token(token)`, which is the Devise scope that handles the digest comparison — do not hand-roll token matching.
+
+## Expiration window
+- Reset window is configured in `config/initializers/devise.rb` as `reset_password_within = 6.hours`. The complete mutation enforces it through `user.reset_password_period_valid?`; the spec asserts this by aging `reset_password_sent_at` past the window.
+
+## Initiate -> worker handoff
+- `PasswordResetInitiate` generates the token synchronously, then hands `(user_id, raw_token)` to `EmailPasswordResetWorker.perform_async`. The token travels through the Sidekiq payload, so the worker does not re-read or regenerate it.
+- The initiate mutation deliberately returns the same empty-errors response whether or not the email matches a user — preserving non-enumeration is part of the contract.
+
+## Complete mutation contract
+- On success, returns a Doorkeeper access token (auto-signs the user in) via the same `access_token_for` helper used by login flows; this couples password reset to the auth-token issuance path.
+- Error strings are stable and asserted by spec: `"Invalid token"`, `"Expired token"`, `"Invalid new password"`. Changing them is a breaking change for the client.
+- Password update goes through `user.reset_password(password, password)` (Devise), which both clears the reset token and runs password validations in one call.
+
+## Email delivery pattern
+- Worker follows the same Mailgun-template pattern as other email workers and is covered by `spec/workers/email_worker_shared_examples.rb` (`"a mailgun worker"`), which standardizes payload shape and HTTP behavior assertions across the email worker family.
+- The Mailgun template name `password-reset` is owned in the Mailgun account, not in the repo; the worker only ships variables.

--- a/autopilot-support/index/features/playlist-management/boundaries.md
+++ b/autopilot-support/index/features/playlist-management/boundaries.md
@@ -1,0 +1,26 @@
+# Playlist Management — Boundaries
+
+## Extension points
+- **New ordering algorithms** — add them inside `app/lib/room_playlist_generator.rb` (or as a sibling class invoked from `Selectors::RoomPlaylistRecords#select` when `historical: false`). The contract is "given a Room and a relation of `RoomPlaylistRecord`, return an Array of records." The selector is the seam; the GraphQL query, the broadcast worker, and the channel payload all flow through it unchanged.
+- **New playlist record states** — extend the `play_state` enum on `RoomPlaylistRecord` rather than introducing parallel state columns. Existing readers branch on `played` vs `waiting`; a new state needs both a generator-side decision (does it appear in the upcoming view?) and a selector-side decision (does it appear in historical?). Update both at the same time.
+- **New mutation semantics** — follow the trio of conventions already established: (1) wrap multi-row writes in `room.with_lock`, (2) call `ensure_user_in_rotation!` when the action implies the user wants to participate, (3) enqueue `BroadcastPlaylistWorker.perform_async(room_id)` after commit. Skip step 3 only when the mutation triggers a queue advance (the queue worker will broadcast).
+- **New broadcast fields** — extend the GraphQL query inside `BroadcastPlaylistWorker#query` and the matching GraphQL type. Subscribers receive whatever the worker projects; do not introduce a second broadcast format.
+- **Historical query filters** — they belong in `Selectors::RoomPlaylistRecords#select` and ride the `played_at` index from `db/migrate/20200407040051_add_played_at_index_to_room_playlist_records.rb`. New filters that need a different index should add the index in the same migration as the selector change.
+
+## Do-not-build
+- **Do not bake queue advancement here.** Advancing `Room#current_record`, flipping `playing_until`, and clearing the `waiting_songs` flag belong to **queue-management**. This feature signals intent (e.g., `abandon` sets `playing_until` to 1 second ago) but never moves the queue itself.
+- **Do not bake playback timing here.** "What is playing right now," `now_playing` channel broadcasts, and clock-driven advancement live in **real-time-playback**. The `played_at` timestamp is written elsewhere; this feature's mutations never set it.
+- **Do not write `RecordListen` rows from playlist mutations.** Listens are a sibling join belonging to **listening-history**. `RoomPlaylistRecord has_many :record_listens` is exposed so the GraphQL type can read them, not so this feature can author them.
+- **Do not query `RoomPlaylistRecord` directly from another feature's GraphQL resolver.** Go through `Selectors::RoomPlaylistRecords` so the future/historical branch and lookahead-driven `includes` stay consistent. The selector is the public read API.
+- **Do not bypass `RoomPlaylistGenerator` for the upcoming view.** A DB-side ordering on `(user_id, order)` is not equivalent — the rotation interleave depends on `Room#current_record` and `Room#user_rotation`, both of which can change between calls.
+- **Do not add cross-user delete or reorder.** Every write path is scoped to `user: current_user`. The single-row delete returns a generic not-found rather than a permission error; do not invert this contract by exposing other users' records.
+- **Do not reintroduce the names "queue" or "room_queues" or "room_songs" for this table.** The three rename migrations document the historical journey to `room_playlist_records`; the word "queue" is now reserved for queue-management.
+
+## Where playlist-management ends
+- `Song` (and YouTube linkage) lives in **features/songs/**. This feature stores `song_id` and exposes the song via the GraphQL type but does not own the model. Song creation, metadata, and YouTube fetching are out of scope.
+- `Room`, `Room#user_rotation`, `Room#current_record`, `Room#waiting_songs`, `Room#playing_until` are owned by **features/rooms/**. This feature reads all of them and writes `waiting_songs` (to `true`) and `playing_until` (via abandon); deeper room lifecycle (creation, activation, ownership) is out of scope.
+- Queue advancement worker and poller live in **features/queue-management/**. The `abandon` mutation is the handoff point: it signals "advance now" via `playing_until = 1.second.ago` and lets the queue worker take it from there.
+- Playback broadcasting and the `NowPlayingChannel` belong to **features/real-time-playback/**. `RoomPlaylistChannel` (this feature's channel) carries the *upcoming* playlist; `NowPlayingChannel` carries the *currently playing* state. Two channels, two features.
+- `RecordListen` rows and the listen-broadcast plumbing live in **features/listening-history/**. The `record_listens` association on `RoomPlaylistRecord` is a read-only seam for this feature.
+- `LibraryRecord` (created as a side effect inside `RoomPlaylistRecordsAdd` via `LibraryRecord.find_or_create_by!`) is owned by **features/music-library/**. The cross-feature write is intentional — adding a song to a room implicitly adds it to the user's library — but the model and its other mutations are out of scope here.
+- `Doorkeeper`/`Devise` auth and `current_user` resolution belong to **features/user-authentication/**.

--- a/autopilot-support/index/features/playlist-management/map.md
+++ b/autopilot-support/index/features/playlist-management/map.md
@@ -1,0 +1,36 @@
+# Playlist Management — Map
+
+## Model
+- `app/models/room_playlist_record.rb` — the Room x Song x User join with `order` and a `play_state` enum (`waiting` / `played`). The single source of truth for "what songs are queued / have been played in a room"; also `has_many :record_listens`.
+
+## GraphQL Types
+- `app/graphql/types/room_playlist_record_type.rb` — exposes `id`, `order`, `played_at`, `record_listens`, `room`, `song`, `user`. `played_at` is the only nullable field — its presence is how clients tell played from waiting in this type.
+
+## GraphQL Mutations
+- `app/graphql/mutations/room_playlist_records_add.rb` — append-only batch add for the current user, increments `order` from the user's current max waiting record; also enrolls user in `Room#user_rotation` and flips `Room#waiting_songs` to true.
+- `app/graphql/mutations/room_playlist_records_reorder.rb` — destructive reorder; treats the input as the new full ordering of the user's waiting records and destroys any waiting record for the user/room not present in the input.
+- `app/graphql/mutations/room_playlist_record_delete.rb` — owner-scoped single-record delete by id; fires `BroadcastPlaylistWorker`.
+- `app/graphql/mutations/room_playlist_record_abandon.rb` — does not touch a record; sets the active room's `playing_until` to 1 second ago, letting the queue worker advance.
+
+## Generator / Selector / Channel / Worker
+- `app/lib/room_playlist_generator.rb` — produces the interleaved upcoming playlist by walking `Room#user_rotation` and ordering each user's waiting records by `order`.
+- `app/lib/selectors/room_playlist_records.rb` — query-time gate: branches between historical (DB-ordered by `played_at`) and future (delegates to `RoomPlaylistGenerator`); resolves GraphQL lookahead into `includes`.
+- `app/channels/room_playlist_channel.rb` — empty subclass; only used as the broadcast topic identified by Room GlobalID.
+- `app/workers/broadcast_playlist_worker.rb` — executes an inline GraphQL query against `roomPlaylist` and broadcasts the result to `RoomPlaylistChannel` for the room.
+
+## Migrations
+- `db/migrate/20190409022601_rename_room_queues_to_room_songs.rb` — first rename: `room_queues` -> `room_songs`. Historical breadcrumb that "queue" was the original name; do not reintroduce.
+- `db/migrate/20190927232332_rename_room_songs.rb` — `room_songs` -> `room_playlist_songs`.
+- `db/migrate/20190927233126_rename_room_playlist_songs.rb` — `room_playlist_songs` -> `room_playlist_records`. The current table name.
+- `db/migrate/20200407040051_add_played_at_index_to_room_playlist_records.rb` — adds the `played_at` index that hot-paths the historical selector and listening-history queries.
+
+## Specs
+- `spec/factories/room_playlist_record.rb` — defaults to `order: 1`, `play_state: "waiting"`; no `played_at` (callers must set it for "played" rows).
+- `spec/models/room_playlist_record_spec.rb` — relationships + enum state; no validation/scope coverage (consistent with repo convention).
+- `spec/mutations/room_playlist_records_add_spec.rb` — confirms append order and starting-from-max behavior.
+- `spec/mutations/room_playlist_records_reorder_spec.rb` — covers reorder, deletion of absent records, mixed new+existing entries, user-rotation enrollment, and the "ignore unprocessable" semantics (gaps in `order` are accepted).
+- `spec/mutations/room_playlist_record_abandon_spec.rb` — three guard paths: not in room, no current record, not owner.
+- `spec/mutations/room_playlist_record_delete_spec.rb` — owner-scoped deletion; asserts `BroadcastPlaylistWorker.perform_async` is enqueued.
+- `spec/lib/room_playlist_generator_spec.rb` — interleaving correctness when `current_record` is set; empty-rotation fallback.
+- `spec/workers/broadcast_playlist_worker_spec.rb` — drives the full broadcast end-to-end and asserts the interleaved payload on `RoomPlaylistChannel`.
+- `spec/queries/room_playlist_spec.rb` — `roomPlaylist` query: future ordering, historical reverse ordering by `played_at`, and the `from` filter (despite filename being "Messages Query").

--- a/autopilot-support/index/features/playlist-management/patterns.md
+++ b/autopilot-support/index/features/playlist-management/patterns.md
@@ -1,0 +1,33 @@
+# Playlist Management — Patterns
+
+## RoomPlaylistRecord is the join, not Room.songs
+- The Room <-> Song relationship goes through `RoomPlaylistRecord` exclusively. There is no `room.songs` direct association; everything (queued, played, ordering, listens) is a row in this table. Treat `RoomPlaylistRecord` as the unit of work whenever code talks about "the playlist."
+- A row's role is determined by `play_state` (`waiting` vs `played`) and `played_at` (set only when transitioning to `played`). The GraphQL type exposes only `played_at`, not `play_state` — clients distinguish state by presence of `played_at`.
+- `order` is **per-user**, not per-room. Two users can both have a record with `order: 0`; the rotation interleaves them. This is why `RoomPlaylistRecordsAdd` reads `latest_record` filtered by `user: current_user` before appending.
+
+## Generator builds the playlist from Room#user_rotation
+- `RoomPlaylistGenerator#playlist` is the canonical view of "what's coming up." It is not a DB ordering — it is a Ruby-side interleave of the rotation array.
+- Algorithm: take the rotation, rotate it so the user *after* `room.current_record.user_id` is first, then for each round-robin position fill in that user's next waiting song. The result is a flat array where slot `n` is `rotation[(n) % rotation.size]`'s `n / rotation.size`-th waiting song.
+- The generator runs `room.with_lock` even though it is read-only — it is reading `current_record` and `user_rotation` together, and the lock prevents a queue advance from happening mid-build.
+- When `user_rotation` is empty the playlist is empty. Adding a record via `RoomPlaylistRecordsAdd` or `RoomPlaylistRecordsReorder` enrolls the current user in the rotation as a side effect (`ensure_user_in_rotation!`).
+
+## Selector composition for queries
+- `Selectors::RoomPlaylistRecords` is the only thing wired into the `roomPlaylist` GraphQL query. It receives a `lookahead` and resolves it into `RoomPlaylistRecord.includes(...)` for the requested associations (`:record_listens`, `:song`, `:user`) — this is how the selector avoids N+1 without forcing eager loading on every call.
+- The same selector branches on the `historical:` argument: historical reads go straight to AR (`played` scope, `played_at desc`, optional `from` filter), while the future view delegates to the generator. The selector is the seam — neither caller knows which branch produced its rows.
+- The historical path is the reason for the `played_at` index migration (`20200407040051_add_played_at_index_to_room_playlist_records.rb`). Any new query that filters or orders by `played_at` should ride that index.
+
+## Mutation semantics — append vs replace
+- `RoomPlaylistRecordsAdd` is **append-only**: it computes `starting_order` from the user's current max waiting `order` and assigns sequential indices. It never reorders existing rows. The `with_lock` protects the order-read-then-write race.
+- `RoomPlaylistRecordsReorder` is **destructive replace**: the input list is treated as the new full ordering of the user's waiting records. Anything not present is `destroy_all`'d, scoped tightly by `user: current_user`, `room: current_user.active_room_id`, `waiting` state. Played records and other users'/rooms' records are untouched by design — this is asserted in spec.
+- Reorder accepts mixed entries: items with `roomPlaylistRecordId` are updated; items with only `songId` create new records. Items that cannot be processed (nonexistent song, record owned by another user) are silently skipped; the resulting `order` values are allowed to have gaps (e.g., 1 and 3). "Relative ordering is fine" is the documented contract.
+- `RoomPlaylistRecordDelete` is single-record and owner-scoped via the `find_by(id:, user:)` pattern. Cross-user delete attempts return `"Can't find song to delete"` (not a permission error string).
+- `RoomPlaylistRecordAbandon` does **not** delete or mutate the playlist record at all — it sets `Room#playing_until` to 1 second ago. The actual queue advancement is in queue-management; this mutation is a "skip my current song" signal.
+
+## Broadcast fan-out
+- Three mutations (`add`, `reorder`, `delete`) explicitly enqueue `BroadcastPlaylistWorker.perform_async(room_id)`. `abandon` deliberately does not (the queue worker will broadcast after it advances).
+- The worker re-executes the `roomPlaylist` GraphQL query with `override_current_user: true` — it does not call the selector directly. This means broadcasts always reflect the post-commit DB state and any future GraphQL-layer logic added to the field is honored.
+- The broadcast carries a fixed GraphQL projection (`id, order, song { id, durationInSeconds, name, thumbnailUrl, youtubeId }, user { id, email, name }`). Subscribers receive exactly this shape; changing it is a client contract change.
+- `RoomPlaylistChannel` itself is an empty class — the channel exists solely as a topic identifier; subscription/auth logic is in `ApplicationCable`.
+
+## Locking and waiting_songs flag
+- Both `add` and `reorder` wrap the write in `room.with_lock` and flip `Room#waiting_songs` to true if it isn't already. That flag is read by queue-management; this feature owns flipping it on, queue-management owns flipping it off.

--- a/autopilot-support/index/features/queue-management/boundaries.md
+++ b/autopilot-support/index/features/queue-management/boundaries.md
@@ -1,0 +1,25 @@
+# Queue Management — Boundaries
+
+## Extension points
+
+- **New advancement triggers** (skip, force-next, admin nudge) should enqueue `QueueManagementWorker.perform_async(room_id)` directly after toggling the relevant `Room` state. The worker's `queue_processing?` / `playing_until` guards keep it safe to call ad-hoc; just remember the poller will *not* claim a room with `playing_until` still in the future, so a force-skip needs to clear or backdate `playing_until` first.
+- **Alternative scheduling** (e.g., replacing Clockwork with Sidekiq-Cron, AWS EventBridge, or an in-process scheduler) only needs to call `RoomQueuePoller.new.poll!` on whatever cadence is desired. The poller has no Clockwork coupling. Cadence change is a knob in `config/clock.rb` (`every(1.second, "room-poll")`).
+- **New selection conditions** for which rooms need advancement go in `RoomQueuePoller`'s private scope builders (`newly_enqueued`, `recently_finished_playing`). Compose them with `.or` to preserve the single `update_all` claim step.
+- **New post-advancement side effects** plug in as additional `*.perform_async` calls in `QueueManagementWorker#perform`, alongside the existing broadcast fan-out. Keep them outside `update_room!` so they only fire when advancement actually happened.
+
+## Do-not-build
+
+- **Do not tie playback timing to this worker.** The worker does not "play" a song — it only records that the room *should be* playing one and broadcasts the change. Clients drive actual playback off the `NowPlaying` channel; that responsibility lives in **real-time-playback**.
+- **Do not introduce a parallel queue table.** The `room_queues` migration and its rename to `room_songs` are historical; the queue today is the `waiting`-state subset of `room_playlist_records`. New queue features extend that model, not a sibling table.
+- **Do not write `queue_processing` or `playing_until` from outside `Room#idle!` / `Room#playing_record!` / the poller's claim step.** The 1Hz idempotency contract depends on exactly those three sites managing the flag. The poller is the only allowed *setter* to `true`; the worker (via `Room` helpers) is the only allowed *clearer*.
+- **Do not call `QueueManagementWorker.perform_async` from request controllers without first ensuring the room's flags reflect intent.** The worker's first action inside the lock is to bail if `queue_processing?` is false — silent no-ops are easy to create here.
+- **Do not loosen the row lock** in `update_room!`. The lock is what keeps a manual trigger from racing the poller.
+
+## Where queue-management ends
+
+- **Playlist mutation** — selecting *which* record plays next, ordering, rotation fairness, and the `waiting` / `played` state machine on `RoomPlaylistRecord` belong to **playlist-management**. This feature only consumes `RoomPlaylistGenerator` and writes `play_state: "played"` + `played_at` on the advancing record.
+- **NowPlaying broadcast and the `NowPlaying` channel** belong to **real-time-playback**. This feature fires `BroadcastNowPlayingWorker` but owns nothing about the broadcast payload, the channel, or client synchronization.
+- **Playlist broadcast** belongs to **playlist-management** (`BroadcastPlaylistWorker`). This feature triggers it on advancement but does not own it.
+- **Team broadcast** (active-room change, room idling visibility on the team) belongs to **teams**. This feature triggers `BroadcastTeamWorker` after advancement but does not own its payload.
+- **The `waiting_songs` write path** from playlist mutations lives in **playlist-management**. This feature only reads the flag in the poller.
+- **`Room#idle!` and `Room#playing_record!`** are defined on the `Room` model and conceptually belong to **rooms**, but they exist almost exclusively to serve this feature. Changes to them should be coordinated with this feature's invariants (clearing `queue_processing`, deriving `playing_until` from song duration).

--- a/autopilot-support/index/features/queue-management/map.md
+++ b/autopilot-support/index/features/queue-management/map.md
@@ -1,0 +1,20 @@
+# Queue Management — Map
+
+## Polling
+
+- `app/lib/room_queue_poller.rb` — selects rooms that need queue advancement (either `playing_until` has passed, or `waiting_songs: true` with no current playback), flips them to `queue_processing: true` in a single `update_all`, and enqueues a `QueueManagementWorker` for each. Invoked from the Clockwork process.
+
+## Workers
+
+- `app/workers/queue_management_worker.rb` — advances a single room. Loads the room, takes a row lock, no-ops unless `queue_processing?` is set and `playing_until` is in the past, asks `RoomPlaylistGenerator` for the next waiting record, marks it played and calls `Room#playing_record!` (or `Room#idle!` if nothing is waiting). On success fans out `BroadcastTeamWorker`, `BroadcastNowPlayingWorker`, and `BroadcastPlaylistWorker`.
+
+## Schema
+
+- `db/migrate/20190322030346_create_room_queues.rb` — original `room_queues` table (room/song/user/order). Renamed to `room_songs` the following month and ultimately superseded by `room_playlist_records`; the table is no longer the queue substrate.
+- `db/migrate/20200205061306_add_waiting_songs_to_room.rb` — adds the `waiting_songs` boolean flag on `rooms` that the poller uses to detect freshly-enqueued playlists with no active playback.
+- `db/migrate/20200223055015_add_queue_processing_to_room.rb` — adds the `queue_processing` boolean flag on `rooms` (default `false`); the poller sets it and the worker clears it on `playing_record!` / `idle!`.
+
+## Specs
+
+- `spec/lib/room_queue_poller_spec.rb` — enumerates which `(playing_until, waiting_songs, queue_processing)` triples enqueue and which are skipped; the canonical reference for the selection rules.
+- `spec/workers/queue_management_worker_spec.rb` — covers empty-queue idling, the "already playing" and "not processing" no-ops, transition to the next record, played-at stamping, `playing_until` derivation from song duration, broadcast fan-out, and `user_rotation` pruning of stale users.

--- a/autopilot-support/index/features/queue-management/patterns.md
+++ b/autopilot-support/index/features/queue-management/patterns.md
@@ -1,0 +1,36 @@
+# Queue Management — Patterns
+
+## Clockwork-driven 1Hz polling
+
+- `config/clock.rb` runs `RoomQueuePoller#poll!` every second from a dedicated Clockwork process (see `structures/infrastructure.md`). There is no per-room timer or ActiveSupport-scheduled job; advancement latency is bounded by this tick.
+- The clock process is separate from the web and worker dynos. Stopping it stops all queue advancement silently — there is no fallback path.
+
+## Two-condition room selection
+
+- The poller picks rooms by OR-ing two disjoint conditions: `recently_finished_playing` (`playing_until <= now AND NOT queue_processing`) and `newly_enqueued` (`playing_until IS NULL AND waiting_songs AND NOT queue_processing`). The `queue_processing` guard is what makes the 1Hz poll idempotent — once a room is claimed, subsequent ticks skip it until the worker clears the flag.
+- Claiming happens via `Room.where(...).update_all(queue_processing: true)` *before* enqueuing the worker, and the relation is materialized to an array first because `update_all` clears the relation as a side effect (see the inline comment).
+
+## `waiting_songs` is a hint, not a count
+
+- `waiting_songs` is a boolean flag flipped to `true` by mutations that enqueue songs (`RoomPlaylistRecordsAdd`, `RoomPlaylistRecordsReorder`) and back to `false` only by `Room#idle!`. It is not authoritative — `RoomPlaylistGenerator` is what actually decides whether a next record exists. The flag exists so the poller can cheaply filter idle rooms with no work to do.
+
+## Worker uses a row lock for serialization
+
+- `QueueManagementWorker#update_room!` wraps everything in `room.with_lock`. Concurrent workers (e.g., a manual `perform_async` racing with the poller) are serialized at the DB row, so only one path through `playing_record!` / `idle!` runs at a time.
+- Inside the lock, the worker re-checks `queue_processing?` and `playing_until&.future?` and bails on either — these are the guards that make the "did nothing because already playing" / "did nothing because not claimed" cases safe.
+
+## `playing_until` is derived from song duration
+
+- `Room#playing_record!` computes `playing_until` as `record.song.duration_in_seconds.seconds.from_now` at the moment of advancement. This is the *only* source of truth for when the current song ends; the poller reads it back on the next tick to decide whether to advance. There is no separate timer or broadcast that ends the song.
+
+## Next-record selection delegates to the playlist generator
+
+- The worker does not implement playlist ordering. It calls `RoomPlaylistGenerator.new(room, relation).playlist.first`, which is the same generator that powers the playlist query — see **playlist-management**. Rotation logic, per-user fairness, and the meaning of `play_state: "waiting"` live there, not here.
+
+## User rotation pruning on advancement
+
+- `remove_stale_user_from_room!` removes the previous record's user from `room.user_rotation` only if they are no longer active in the room *and* have no remaining waiting records. This is the cleanup hook for users who left mid-song; the playlist generator relies on `user_rotation` to decide who plays next.
+
+## Broadcast fan-out is fire-and-forget
+
+- After a successful advancement (or successful idle transition), the worker enqueues three downstream broadcast workers. It does not wait for them and does not retry them as a group — Sidekiq retries each independently. The trio always fires together; partial fan-out is not a supported state.

--- a/autopilot-support/index/features/real-time-playback/boundaries.md
+++ b/autopilot-support/index/features/real-time-playback/boundaries.md
@@ -1,0 +1,24 @@
+# Real-time Music Playback — Boundaries
+
+## Where this feature ends
+
+- **Queue advancement** — choosing the next record, locking the room, updating `play_state`/`played_at`/`playing_until`, and detecting expiration lives in `features/queue-management/` (`QueueManagementWorker`, `RoomQueuePoller`, `config/clock.rb`, `lib/tasks/room.rake`). This feature only fires *after* queue-management has finished its update.
+- **Playlist composition** — `RoomPlaylistGenerator`, the user-rotation logic, the add/reorder/abandon mutations, and the `RoomPlaylistChannel` broadcast all live in `features/playlist-management/`. The `playedAt`/`play_state` columns are read here but written there.
+- **Skip-current-song** — `RoomPlaylistRecordAbandon` mutation sets `room.playing_until = 1.second.ago` and lets the poller pick it up. That mutation belongs to `features/playlist-management/`; this feature only sees the resulting broadcast.
+- **Song metadata and duration** — `durationInSeconds` is sourced from `Song` (populated by YouTube ingestion in `features/youtube/`). If a song has the wrong duration, clients will stop early or late — fix it in the song record, not here.
+- **Channel auth** — handled by `ApplicationCable::Channel#subscribed` and `ApplicationCable::Connection` (`features/user-authentication/`). This feature inherits room-scoping for free; do not add subscription guards here.
+
+## Extension points
+
+- **Adding fields to the broadcast payload** — edit the inline GraphQL query in `BroadcastNowPlayingWorker#query`. Anything resolvable on `room.currentRecord` (record, song, user) is fair game. Adding a new top-level field would require either a new query path or a new channel + worker.
+- **A new synchronization channel** — if you need a separate stream (e.g., per-listener seek position, ad markers, reactions), follow the `broadcast_*` family pattern: empty channel subclass, dedicated worker on its own named queue, inline GraphQL query, `override_current_user: true` context. Enqueue from wherever the source-of-truth state mutation happens. See `autopilot-support/index/structures/modules.md` for the family.
+- **A new playback origin** — if you need something other than `played_at` as the sync anchor (e.g., paused-and-resumed offsets), add a column to `room_playlist_records` and include it in the worker's GraphQL query. Do not encode it into `playing_until` — that column is owned by the poller's expiration scan.
+
+## Do not build
+
+- **Do not drive playback timing from the client.** The server is authoritative about *what* is playing and *when* it started (`playedAt`). Clients compute their own playhead but do not report it back, and do not request "seek to t=X". There is no resume / pause / seek protocol — adding one means rethinking `playing_until` semantics with `QueueManagementWorker`.
+- **Do not tie real-time playback to specific songs.** The broadcast payload speaks in terms of the current `RoomPlaylistRecord` (with the song nested inside). Don't write code that subscribes to "song X is playing" — songs are reused across rooms and across records. Always go through the record.
+- **Do not add a periodic re-sync broadcast.** Clients sync once at queue-advance time and one-shot-query on join. If you find yourself wanting a heartbeat, the right fix is usually a join-time fetch or a longer broadcast payload — not a recurring broadcast (which would multiply Sidekiq load by the number of active rooms).
+- **Do not invoke `BroadcastNowPlayingWorker` from mutations or controllers.** Its only legitimate caller is `QueueManagementWorker`. Firing it elsewhere risks broadcasting stale state because the room may not yet be locked or the record may not yet be `played`.
+- **Do not surface `rooms.playing_until` to clients.** It is a server-side scan column, not a sync timestamp.
+- **Do not give `NowPlayingChannel` a body.** Subscription params, per-room filters, or custom `subscribed` logic break the inherited room-scoping pattern and will diverge from the rest of the `broadcast_*` family.

--- a/autopilot-support/index/features/real-time-playback/map.md
+++ b/autopilot-support/index/features/real-time-playback/map.md
@@ -1,0 +1,11 @@
+# Real-time Music Playback — Map
+
+This feature broadcasts the currently-playing record (song + start timestamp) to every client subscribed to a room, so clients can render synchronized playback without polling. It is intentionally tiny: a no-body channel, one worker that re-runs a GraphQL query and pushes the result, plus the two schema columns (`rooms.playing_until` and `room_playlist_records.{play_state,played_at}`) that other features read to know what "now playing" means.
+
+## Files
+
+- `app/channels/now_playing_channel.rb` — `NowPlayingChannel`. Empty class; inherits `subscribed` from `ApplicationCable::Channel` so it streams to `current_user.active_room`. The room-keyed stream is what makes "playback for *my* room" work without per-channel code.
+- `app/workers/broadcast_now_playing_worker.rb` — `BroadcastNowPlayingWorker`. Sidekiq job on the `broadcast_now_playing` queue. Re-executes a hardcoded GraphQL query (`room.currentRecord` with `playedAt`, song details, and user) through `MusicboxApiSchema.execute` with `context: { override_current_user: true }` (skips auth), then calls `NowPlayingChannel.broadcast_to(Room.find(room_id), payload)`. Enqueued exclusively by `QueueManagementWorker` after a successful queue advance.
+- `db/migrate/20190606130002_add_play_state_and_played_at_to_room_songs.rb` — adds `play_state` (string, indexed) and `played_at` (datetime) to what was then `room_songs` (now `room_playlist_records`). `played_at` is the wall-clock value the broadcast payload returns as `playedAt` and that clients use as the playback origin.
+- `db/migrate/20200205052424_add_playing_until_to_room.rb` — adds `rooms.playing_until` (datetime, indexed). Computed by `Room#playing_record!` as `record.song.duration_in_seconds.seconds.from_now`; consumed by `RoomQueuePoller` to find rooms whose playback has expired. Not in the broadcast payload — clients derive end-time from `playedAt + durationInSeconds`.
+- `spec/workers/broadcast_now_playing_worker_spec.rb` — single example asserting both the song name and `playedAt` survive the GraphQL round-trip, using RSpec's `have_broadcasted_to(room).from_channel(NowPlayingChannel)` matcher.

--- a/autopilot-support/index/features/real-time-playback/patterns.md
+++ b/autopilot-support/index/features/real-time-playback/patterns.md
@@ -1,0 +1,29 @@
+# Real-time Music Playback — Patterns
+
+## Room-keyed stream, channel has no body
+
+`NowPlayingChannel` is literally an empty subclass. Subscription routing is inherited from `app/channels/application_cable/channel.rb`, which does `stream_for current_user.active_room`. That means a client's subscription target is always "the room I am currently in" — there is no client-supplied room id, no `params[:room_id]` to validate. Switching rooms (changing `users.active_room_id`) requires the client to resubscribe to pick up the new stream. This pattern is shared with `MessageChannel`, `PinnedMessagesChannel`, `RecordListensChannel`, and `RoomPlaylistChannel`.
+
+## Broadcast payload is the GraphQL response, not a hand-rolled DTO
+
+`BroadcastNowPlayingWorker` re-runs an inline GraphQL query string through `MusicboxApiSchema.execute` and broadcasts `now_playing.to_h` directly. The result is the client receives the exact shape of a `room.currentRecord` query response (including the `data:` envelope and any `errors`) — the same shape it would get from an HTTP query. Clients can reuse the GraphQL response normalization they already have for queries.
+
+This avoids drift between query and subscription payloads but couples the broadcast to the worker's hardcoded query string. Changing fields requires editing the heredoc in the worker's private `#query` method; see the broader pattern in `autopilot-support/index/structures/modules.md` under "broadcast_* family".
+
+The worker authenticates by passing `context: { override_current_user: true }` rather than holding a real user — see `app/graphql/types/query_type.rb` for how that bypass works.
+
+## Client-side clock sync via `playedAt`
+
+The broadcast payload sends `playedAt` (when the record actually started playing) but **not** the song duration's end time. Clients compute their playhead as `now - playedAt` and stop when they hit `durationInSeconds` (also in the payload). This is the only synchronization mechanism — there is no periodic re-sync broadcast, no `currentPosition` field, no seek event. A late-joining client gets one `NowPlayingChannel` message at subscription time (because `QueueManagementWorker` doesn't fire on join) — for that case, clients must fall back to a one-shot `room.currentRecord` GraphQL query.
+
+`rooms.playing_until` exists for the server's benefit only. It is the indexed column `RoomQueuePoller` scans every second to find expired playbacks. Do not surface it to clients as a sync source — it is server wall-clock and can drift from `playedAt + durationInSeconds` by milliseconds depending on enqueue latency.
+
+## Broadcast is triggered by queue advancement, not by playback events
+
+`BroadcastNowPlayingWorker.perform_async(room_id)` is enqueued from exactly one place: `QueueManagementWorker#perform` after it successfully advances the room (either to a new record or to idle). It is not called from mutations directly, not called on subscribe, not called on song-create. The implication: "now playing changed" and "the queue advanced" are the same event.
+
+`QueueManagementWorker` is itself enqueued only by `RoomQueuePoller#enqueue_for`, which runs every second via `config/clock.rb` (`Clockwork.every(1.second, "room-poll")`). So the worst-case latency from "song finished playing" to "clients see the next song" is ~1s of poll latency plus Sidekiq scheduling on the `broadcast_now_playing` queue. The `room:poll_queue` rake task in `lib/tasks/room.rake` is an alternative 0.1s-interval poller that exists alongside Clockwork — see `autopilot-support/index/structures/infrastructure.md`.
+
+## `play_state` and `played_at` as the source of truth
+
+The `play_state` enum on `RoomPlaylistRecord` (`played` / `waiting`) is what `RoomPlaylistGenerator` uses to filter the queue — it is not derived from `played_at` being non-null. `QueueManagementWorker` sets both fields in one `update!` when promoting a record. Don't infer one from the other; both must be written together to keep the playlist projection consistent.

--- a/autopilot-support/index/features/recommendations/boundaries.md
+++ b/autopilot-support/index/features/recommendations/boundaries.md
@@ -1,0 +1,43 @@
+# Music Recommendation — Boundaries
+
+What this feature owns, where it ends, and what not to build inside it.
+
+## What this feature owns
+
+- The two mutations `Mutations::RecommendationCreate` and `Mutations::RecommendationAccept`.
+- The semantic meaning of `LibraryRecord.source` values `pending_recommendation` and `accepted_recommendation`, and of the `from_user_id` column when those sources are set.
+- The send-side dedupe rule ("recipient must not already have the song in any form") and the recipient-side authorization rule on accept.
+- The shape and asymmetry of the `recommendations` query field (inbox vs. outbox-by-song) — see Patterns. The field is *registered* in `app/graphql/types/query_type.rb` (owned by the GraphQL surface in `structures/resources.md`), but the filter semantics are this feature's contract.
+
+## Where this feature ends
+
+- **Music library** owns the `LibraryRecord` model, its table, the `source` enum declaration, the `User#library_records` association (and its pending-rec filter), the selector, and `LibraryRecordDelete`. This feature only writes specific `source` values into rows that the library feature defines. Any new column on `library_records`, any change to the enum, or any change to the association-level filter is a music-library change.
+- **Songs** owns the `Song` model and its `youtube_id` lookup. `RecommendationCreate` calling `Song.find_by(youtube_id:)` is a consumer of that interface — it does not own song resolution.
+- **User authentication & management** owns `User` and `current_user`. The `from_user` and `user` associations on `LibraryRecord` resolve to `User` rows that this feature does not create, validate, or update.
+- **Real-time playback / messages / teams broadcast workers** fan out via their own channels. There is no recommendation channel and no recommendation broadcast worker. If a recipient must see a new pending rec in real time, the existing `LibraryRecord`- and `User`-level broadcast paths in those features are the integration point — not new workers under this slug.
+
+## Extension points
+
+- **Adding a "decline" outcome** — add a new value to the `LibraryRecord.source` enum (in `app/models/library_record.rb`, owned by music-library) such as `declined_recommendation`, then add `RecommendationDecline` here that transitions `pending_recommendation` → `declined_recommendation`. Decide whether the `User#library_records` association should also exclude the new value; the existing pending-rec exclusion is the precedent.
+- **Adding context fields to a recommendation** (e.g., a note, a timestamp, a rating) — add the column to `library_records` via a music-library migration, expose it on `Types::LibraryRecordType`, and add the corresponding `argument` to `RecommendationCreate` here. Keep the field on `LibraryRecord` — do not introduce a sidecar `recommendation_metadata` table.
+- **Alternative acceptance flows** (auto-accept, bulk accept, accept-on-play) — add a new mutation here that performs the same `source` update; route the trigger from the relevant feature (e.g., `RecordListenCreate` in listening-history could auto-accept a pending rec when the recipient plays it). The state transition rule lives here even if the trigger lives elsewhere.
+- **Notifications for new/accepted recommendations** — wire into the existing real-time-playback or messages broadcast paths rather than creating a recommendations channel. The recommendation lifecycle is too coarse to justify a dedicated channel; piggyback on the recipient's library/user broadcast.
+- **Recipient-targeting beyond a single user id** — `recommend_to_user` is a single `ID`. To support multi-recipient sends, fan out at the mutation level into N `LibraryRecord.create!` calls inside a transaction; do not introduce a "recommendation group" model.
+
+## Do not build here
+
+- **A `Recommendation` model or `recommendations` table.** The whole feature is intentionally implemented as state on `LibraryRecord`. Migrating to a dedicated model would require splitting `from_user_id`, `tags`, and the music-library selector across two tables for no behavioral gain.
+- **A recommendation-specific ActionCable channel or broadcast worker.** Recipient-facing updates ride on existing channels — see "Where this feature ends" above.
+- **A reverse-direction lookup that returns "users who recommended *me* a song"** under a new mutation. That read already exists via the `recommendations(songId:)` query branch (outbox-by-song); generalize the resolver before adding a sibling.
+- **Authorization beyond user-existence on create.** There is no "are you allowed to recommend to this user" check today (no team/room scoping). If product needs that, it belongs on the read or write side of teams/rooms, not as a side-rule wedged into `RecommendationCreate`.
+- **Source-string magic strings outside this feature's two mutations.** The strings `"pending_recommendation"` and `"accepted_recommendation"` are also referenced from `app/models/user.rb` and `app/graphql/types/query_type.rb#recommendations`. Treat those three reference sites as the closed set; do not scatter the strings further. New consumers should query through the existing query field or selector.
+- **A "remove pending rec" mutation that destroys the row.** `Mutations::LibraryRecordDelete` (music-library) already destroys library rows under `current_user`. A recipient can reject a pending rec today by calling that mutation. Do not duplicate the destroy path here.
+
+## Schema invariants
+
+- A pending or accepted recommendation row's `user` is always the *recipient*; `from_user` is always the *sender*. Flipping that convention in any new code path breaks both the inbox query and the `User#library_records` filter.
+- The dedupe key on send is `(song, user)` across *all* sources. Two rows for the same `(song, recipient)` pair should never exist; the create mutation enforces this but there is no DB-level uniqueness index, so background scripts and direct `LibraryRecord.create!` calls must respect it manually.
+
+## Test boundary
+
+Specs for this feature live in `spec/mutations/recommendation_*_spec.rb` and `spec/queries/recommendations_spec.rb`. They reach across into `LibraryRecord` directly — that is intentional and is the canonical way to assert pending-state behavior, since the `User#library_records` association would hide the rows under test.

--- a/autopilot-support/index/features/recommendations/map.md
+++ b/autopilot-support/index/features/recommendations/map.md
@@ -1,0 +1,16 @@
+# Music Recommendation — Map
+
+Recommendations are not their own model. Every file below operates on `LibraryRecord` with a `source` of `pending_recommendation` or `accepted_recommendation`. See `features/music-library/` for the underlying model and table.
+
+## GraphQL Mutations
+
+- `app/graphql/mutations/recommendation_create.rb` — Creates a `LibraryRecord` on the recipient's library with `source: "pending_recommendation"` and `from_user_id: current_user.id`. Resolves the song by `youtube_id` (not by song id) and refuses to create if the recipient already has any `LibraryRecord` for that song, pending or otherwise.
+- `app/graphql/mutations/recommendation_accept.rb` — Flips the recipient's pending row to `accepted_recommendation` via `update!`. Scopes the lookup to `user: current_user, source: "pending_recommendation"` so only the recipient can accept, and only while pending.
+
+The `recommendations` query field itself lives in `app/graphql/types/query_type.rb` (owned by the GraphQL surface in `structures/resources.md`); it is the read path for both mutations below but is not in the CSV scope of this feature.
+
+## Specs
+
+- `spec/mutations/recommendation_create_spec.rb` — Asserts the created row's `from_user_id` and `pending_recommendation` source, and the two "already has the song" refusals (saved record with empty-string source, and an existing pending row). Confirms the recipient's `user.songs` does *not* include the pending song (the `User#library_records` filter).
+- `spec/mutations/recommendation_accept_spec.rb` — Single happy-path spec: source transitions to `accepted_recommendation`, `from_user` is preserved.
+- `spec/queries/recommendations_spec.rb` — Documents the two modes of the `recommendations` query: with no `songId` it returns the current user's pending inbox; with `songId` it returns the recommendations *the current user has sent* for that song (note: it does not filter by `pending_recommendation` in that branch — accepted outbound recs are included).

--- a/autopilot-support/index/features/recommendations/patterns.md
+++ b/autopilot-support/index/features/recommendations/patterns.md
@@ -1,0 +1,32 @@
+# Music Recommendation — Patterns
+
+## A recommendation is a `LibraryRecord` in a particular state
+
+- There is no `Recommendation` model, table, or migration. Recommendations are `LibraryRecord` rows whose `source` enum (defined in `app/models/library_record.rb`) is `pending_recommendation` (just sent) or `accepted_recommendation` (recipient acknowledged). The recommender is carried on the same row in `from_user_id`.
+- Creation puts the row on the *recipient's* library (`user: to_user`), not the sender's. The sender appears only as `from_user`. Read both `recommendation_create.rb` and `recommendation_create_spec.rb` together — the test's `expect(other_user.songs).not_to include(song)` is the canonical demonstration that "pending" lives on the recipient but is filtered out of their normal song reads.
+
+## "Send" and "accept" are state writes on that row
+
+- `RecommendationCreate` is `LibraryRecord.create!` with the pending source. There is no separate "outbox" record on the sender — the single row encodes both ends of the recommendation via `user` (recipient) and `from_user` (sender).
+- `RecommendationAccept` is a one-field `update!` that flips `source` from `pending_recommendation` to `accepted_recommendation`. It does not create or destroy rows. Re-running it on an already-accepted row returns `"No recommendation"` because the lookup filters on the pending source.
+- There is no decline / reject mutation. The closest equivalent today is `Mutations::LibraryRecordDelete` (owned by **music-library**), which destroys the row outright. If a soft reject is ever needed, add a new `source` enum value rather than a new model.
+
+## Sender-side dedupe is by *any* existing LibraryRecord
+
+- `recommendation_create.rb` refuses creation when `LibraryRecord.exists?(song: song, user: to_user)` regardless of source. That means a recipient who already saved, was historically promoted, or was previously recommended the song cannot receive a fresh recommendation. The "already has song" spec uses `source: ""` (empty string, not `nil`) to assert this — the check is row-presence, not source-equality.
+- Songs are resolved by `youtube_id`, not the GraphQL `id`. The mutation argument is named `youtube_id` and the lookup is `Song.find_by(youtube_id: …)`. Clients that already hold the GraphQL `Song.id` must re-thread the youtube id.
+
+## Recipient's inbox is hidden by the `User#library_records` association
+
+- `User#library_records` in `app/models/user.rb` excludes `source = "pending_recommendation"` via an Arel `not_eq` plus an explicit `or(source IS NULL)` clause. Consequence: pending recs are invisible to anything that traverses `user.library_records` or `user.songs`, including the music-library selector and stats.
+- Reads that *need* to see pending rows must query `LibraryRecord` directly. Both `RecommendationAccept` and the `recommendations` query field on `QueryType` do exactly that — they bypass the association on purpose.
+
+## The `recommendations` query has two modes with different filters
+
+- See `app/graphql/types/query_type.rb#recommendations`. With no `song_id`: returns `current_user`'s pending inbox (`user: current_user, source: "pending_recommendation"`). With `song_id`: returns rows where `from_user: current_user` for that song, with no source filter — accepted outbound recs are included. The two branches are not symmetric and that asymmetry is exercised by `spec/queries/recommendations_spec.rb`.
+- The resolver builds its `includes` from GraphQL lookahead (`:song`, `:user`, `:from_user`) to avoid N+1s. Any new association on `LibraryRecordType` consumed by this query must be added to the lookahead branches there.
+
+## Authorization is implicit in the scoping
+
+- `RecommendationCreate` requires only that the recipient (`to_user`) exists; any authenticated user may send to any other user. There is no team/room scoping today.
+- `RecommendationAccept` authorizes by including `user: current_user` in the `find_by`. A miss returns `"No recommendation"` — the same string is returned for "doesn't exist", "belongs to someone else", and "already accepted". The error is intentionally generic.

--- a/autopilot-support/index/features/rooms/boundaries.md
+++ b/autopilot-support/index/features/rooms/boundaries.md
@@ -1,0 +1,24 @@
+# Rooms — Boundaries
+
+## Extension points
+- New scalar room fields (e.g., description, theme, max users) plug in as columns on `rooms` plus optional surface in `app/graphql/types/room_type.rb`. The existing playback fields (`playing_until`, `queue_processing`, `waiting_songs`) are deliberately *not* exposed in `RoomType` — follow that pattern for any server-side state.
+- New room states are best modeled as additional `Room#…!` instance methods (mirroring `idle!` and `playing_record!`) that wrap a single `update!` of the relevant tuple. Avoid scattering partial updates across callers.
+- New scope or filter mutations should reuse the `Room.find_by(team: current_user.teams)` (any team) vs. `Room.where(team: current_user.active_team)` (active team only) split — that distinction is the existing authorization vocabulary.
+- Membership / presence changes belong on `User` (via `active_room_id`), not on `Room`. Add new "join" semantics by adding User-side writes plus a broadcast, as `RoomActivate` does.
+- The `user_rotation` `uuid[]` column is the seam for any DJ-order feature. Append/remove with Postgres array ops or full overwrite; do not introduce a parallel join table.
+
+## Do-not-build
+- Do not bake playlist logic into `Room`. The `room_playlist_records` association is for traversal; queue ordering, adding songs, abandoning records, and reorder operations belong in **playlist-management**.
+- Do not bake queue advancement into `Room`. `Room#playing_record!` and `idle!` are atomic transitions called *from* the queue worker — the room never schedules its own next song, polls itself, or owns the timing loop.
+- Do not have `Room` write to channels directly. Activation enqueues `BroadcastTeamWorker`; any future room-state broadcast should go through the same worker pattern, not `ActionCable.server.broadcast` inline.
+- Do not expose `user_rotation`, `playing_until`, `queue_processing`, or `waiting_songs` in `RoomType` without a deliberate cross-feature review. These are server-controlled and clients consume their effects via the now-playing channel.
+- Do not let `RoomCreate` activate the creator's `active_room`. Create and activate are intentionally separate steps; collapsing them would break the "create in active team, then join" client flow.
+- Do not introduce ownership / role columns on `Room` (no `owner_id`, no admin flags). Authorization is mediated through team membership and `active_team` — adding room-level roles would fork the auth model.
+
+## Where rooms ends
+- **playlist-management** owns `RoomPlaylistRecord` (the join), including add/reorder/abandon mutations and the playlist generator. `Room` only reads the join to expose `current_record` and `current_song`.
+- **queue-management** owns the queue advancement worker and the poller. It calls `Room#idle!` and `Room#playing_record!` from outside; those methods belong to this feature, but the scheduling logic does not.
+- **real-time-playback** owns `NowPlayingChannel` and the broadcast worker that pushes room playback state to clients. The room model holds the state; the channel feature ships it.
+- **messages** owns `Message` (which `belongs_to :room`). The Room model does not declare the inverse association; if you need to enumerate a room's messages, query `Message` directly.
+- **teams** owns `Team`, `TeamUser`, and the `active_team` activation surface. `Room.team` is a non-optional belongs-to into that feature; team lifecycle and membership questions stop at the team boundary.
+- **user-authentication** owns `users.active_room_id` as a column on `User`; rooms-feature code writes to it (via `RoomActivate`), but the column, its index, and the `has_many :users` inverse live with the user model.

--- a/autopilot-support/index/features/rooms/map.md
+++ b/autopilot-support/index/features/rooms/map.md
@@ -1,0 +1,28 @@
+# Rooms — Map
+
+## Model
+- `app/models/room.rb` — `Room` belongs to `team`, has many users via `active_room_id` (not `room_id`), has many `room_playlist_records` and `songs` through them; exposes `idle!` and `playing_record!` state transitions and an internal `playing_until_datetime` derived from the current record's song duration.
+
+## GraphQL Mutations
+- `app/graphql/mutations/room_create.rb` — creates a room scoped to `current_user.active_team`; relies on `belongs_to :team` to reject creation when the user has no active team (yields `"Team must exist"`).
+- `app/graphql/mutations/room_activate.rb` — swaps the calling user's `active_room_id` and `active_team_id`, then enqueues `BroadcastTeamWorker`; team membership is enforced by the `Room.find_by(team: current_user.teams)` lookup.
+
+## GraphQL Types
+- `app/graphql/types/room_type.rb` — exposes `name`, `id`, `users`, `current_record`, and `current_song`; deliberately does not expose `user_rotation`, `playing_until`, `queue_processing`, or `waiting_songs` (server-side rotation/playback state).
+
+## Migrations
+- `db/migrate/20190218193526_create_room.rb` — base `rooms` table with uuid primary key and `name`.
+- `db/migrate/20190218194925_add_room_to_user.rb` — adds `room_id` to `users` (later renamed; see below).
+- `db/migrate/20190606125833_add_user_rotation_to_rooms.rb` — adds `user_rotation` as a Postgres `uuid[]` column with default `{}` (ordered DJ queue, not a join table).
+- `db/migrate/20190928195833_update_room.rb` — renames `current_song_id` to `current_record_id` and drops `current_song_start` (room now points at a playlist record, not a song directly).
+- `db/migrate/20191231013211_update_room_for_user.rb` — renames `users.room_id` to `users.active_room_id` (the "active room" framing is post-hoc).
+
+## Factories
+- `spec/factories/room.rb` — default factory leaves `current_record`, `playing_until`, and `waiting_songs` cleared; always builds a team association.
+
+## Specs
+- `spec/models/room_spec.rb` — covers the `users` / `room_playlist_records` / `songs` / `current_record` / `current_song` association graph.
+- `spec/mutations/room_create_spec.rb` — documents the `active_team`-scoped create contract and the `"Team must exist"` / `"Name can't be blank"` error strings.
+- `spec/mutations/room_activate_spec.rb` — asserts cross-team room activation is rejected and that `BroadcastTeamWorker` is enqueued on success.
+- `spec/queries/room_spec.rb` — single-room visibility is constrained to rooms whose team the current user is on; unauthenticated requests get `unauthorized` rather than `nil`.
+- `spec/queries/rooms_spec.rb` — list query is scoped to `current_user.active_team` (not `teams`), so users with no active team see an empty list.

--- a/autopilot-support/index/features/rooms/patterns.md
+++ b/autopilot-support/index/features/rooms/patterns.md
@@ -1,0 +1,28 @@
+# Rooms — Patterns
+
+## Lifecycle: create vs. activate
+- `RoomCreate` is a pure persistence step. It does not move the calling user into the room — creating a room never changes `active_room_id`. A client that wants the creator inside must follow up with `RoomActivate`.
+- `RoomActivate` is per-user, not per-room. It mutates the caller's `User` (`active_room_id`, `active_team_id`); the `Room` row itself is not touched. "Joining" a room is therefore a User-side write, which is why `Room.users` is keyed by `active_room_id`.
+- The activate mutation also flips `active_team_id` to match the room's team. This is the canonical way a user's active team changes via room navigation — clients do not need to call a team-activate mutation first.
+
+## Team scoping
+- Room visibility is layered by query:
+  - `room(id:)` (single) — scoped to `current_user.teams` (any team the user is on).
+  - `rooms` (list) — scoped to `current_user.active_team` only. Users with `active_team: nil` get an empty list, not all-teams-they-belong-to.
+  - `roomActivate` — scoped to `current_user.teams`, matching the single-room query.
+- `RoomCreate` always assigns `current_user.active_team`. There is no API to create a room in a non-active team; switching teams first is required.
+- `Room` `belongs_to :team` is non-optional (default Rails 5+ behavior); deleting the team-less path is enforced by validation, not by a DB constraint check at the room layer.
+
+## Playback / rotation state lives on Room
+- `Room` carries the playback cursor: `current_record_id` (FK to `RoomPlaylistRecord`), `playing_until` (timestamp), `queue_processing` (bool), `waiting_songs` (bool). The room is the single source of truth for "what's playing right now."
+- `user_rotation` is a Postgres `uuid[]` ordered list of user ids — the DJ rotation order, not a membership list. Membership is `users.active_room_id`. Treat `user_rotation` as a sequence; do not assume set semantics.
+- `Room#idle!` clears the entire playback tuple atomically (`current_record`, `playing_until`, `queue_processing`, `waiting_songs`). `Room#playing_record!(record)` advances the cursor and computes `playing_until` from `record.song.duration_in_seconds.seconds.from_now`. Both wrap `update!`, so callers do not need to manage individual fields.
+- `playing_until` is computed at write time from server clock + song duration. There is no recurring "tick" updating it — consumers compare against `Time.now` themselves.
+
+## Activation broadcast
+- After flipping the user's active room/team, `RoomActivate` enqueues `BroadcastTeamWorker` for the room's team. Real-time clients learn that membership changed via the team-level broadcast, not via a per-room channel write from the mutation.
+
+## Relationships to neighboring features
+- Playlist: rooms have many `room_playlist_records`; the `current_record` and `current_song` accessors traverse that join. The room owns the cursor; the join table owns the queue ordering.
+- Queue advancement: the room exposes the levers (`queue_processing`, `playing_until`) but does not advance itself. The queue feature reads/writes these fields from outside.
+- Messages: messages are per-room (a `Message belongs_to :room`); the room itself has no `has_many :messages` declaration here.

--- a/autopilot-support/index/features/search/boundaries.md
+++ b/autopilot-support/index/features/search/boundaries.md
@@ -1,0 +1,50 @@
+# Search Functionality — Boundaries
+
+What this feature owns, where it ends, and what not to build inside it.
+
+## What this feature owns
+
+- The `search` GraphQL query field's orchestration (the selector, not the field declaration itself, which is wired in `app/graphql/types/query_type.rb`).
+- `Types::SearchResultType` — the union over `SongType` and `YoutubeResultType` and the `resolve_type` dispatch.
+- `Selectors::SearchResults` — the local-first / YouTube-fallback orchestration and the library-exclusion subquery.
+- The `pg_trgm` extension enablement and the GIN trigram index on `songs.name`.
+- The semantics of "what `search` returns to the GraphQL client" (a heterogeneous list, never blended).
+- Request-level specs for the `search` query.
+
+## Where this feature ends
+
+- **`Song`'s search scopes (`search`, `fulltext_search`, `fuzzy_search`) live in `features/songs/`.** Even though they exist *for* search, they are model behavior on `Song`. This feature consumes them (or, currently, fails to — see Patterns). Adding a new tier or changing weights happens in `app/models/song.rb` and its specs.
+- **The `text_search` generated column, `immutable_array_to_string` SQL function, and the multi-column trigram GiST index live in `features/songs/`.** They are part of the Song schema. The GIN trigram index on `songs.name` is the one piece of search-specific schema owned here because it predates the `text_search` migration and was added explicitly to support search.
+- **`YoutubeClient` and the YouTube API integration live in `features/youtube/`.** This feature calls `YoutubeClient#search`; it does not own the client, its credentials, or the `OpenStruct` shape it returns.
+- **`LibraryRecord` lives in `features/music-library/`.** This feature reads `LibraryRecord.select(:song_id).where(user:)` for exclusion but does not own the join table.
+- **The `search` field's *declaration* and `confirm_current_user!` line live in `app/graphql/types/query_type.rb`** (documented under `structures/resources.md`). This feature owns the body the field calls into, not the field plumbing.
+- **`Tag`, `TagLibraryRecord`, and tag-driven discovery live in `features/tagging/`.** Tag matching is currently subsumed by `songs.youtube_tags` (a string array on the song), not the `Tag` model. See "Do not build" below.
+
+## Extension points
+
+- **A new searchable entity (e.g., adding `Playlist` or `Tag` to search results).** Add the model as a new branch in `Selectors::SearchResults#search`, add the type to `Types::SearchResultType.possible_types`, add a `when ModelClass` branch to `resolve_type`, and update `spec/queries/search_spec.rb` to cover the new branch. **If the new entity's text search needs to participate in the same 3-tier ranking, give it its own `search` scope on its own model** (mirror the pattern in `Song.search`) rather than centralizing rank logic in the selector — that keeps Postgres planning per-table and the indexes co-located with the schema.
+- **A new ranking tier on `Song.search`.** Edit `app/models/song.rb` (under `features/songs/`). Add the tier's predicate as another `OR` in the `WHERE`, insert the tier into both `CASE` arms in the `ORDER BY`, and update `spec/models/song_spec.rb`. If the tier needs a new index, roll a migration — name it explicitly under `db/migrate/` rather than amending an existing search migration.
+- **Wire the selector to use `Song.search` instead of ILIKE-on-name.** Replace `Song.where(Song.arel_table[:name].matches("%query%"))` with `Song.search(query)` in `from_all_songs`. Then re-confirm `spec/queries/search_spec.rb` (the current spec is written to ILIKE semantics — the "song" → `other-song` match passes either way, but any future test that depends on tier ordering will need to follow this change).
+- **Result pagination.** The `search` field currently returns a plain array. To paginate, switch the GraphQL field to a `connection_type` (or implement cursor pagination by hand on the selector) and slice in the selector — the trigram operators support `ORDER BY similarity DESC LIMIT N` efficiently because the GiST index supports `<<->` ordering.
+- **Plumbing the unused `lookahead`.** `Selectors::SearchResults` already accepts and stores it. To enable N+1 prevention, inspect `@lookahead.selection(:song).selects?(:library_records)` (or similar) inside `from_all_songs` and `.includes(:library_records)` conditionally.
+
+## Do not build here
+
+- **Do not add Elasticsearch, OpenSearch, Meilisearch, Algolia, Typesense, or any external search index.** The Postgres `pg_trgm` + `tsvector` path is intentional. Adding an external index introduces a sync problem (background indexer, eventual consistency, deploys must include reindex steps, environments diverge) that the team has not chosen to take on. The 3-tier scope on `Song.search` is the chosen ceiling for ranking sophistication.
+- **Do not search `Tag` or `LibraryRecord` directly.** Tag matching is currently delegated to the `youtube_tags` text array column on `Song`, included in the `text_search` tsvector (weight `B`) and the multi-column trigram expression. Searching the `Tag` model or `tag_library_records` table would create two parallel discovery paths — pick one. If product wants user-applied tags to drive search hits, extend `text_search`'s expression to include them (and roll a new migration to regenerate the column) rather than adding a new selector branch.
+- **Do not search `LibraryRecord`** — it has no user-facing text fields. If you need to expose a library-only filter (e.g., "search inside my library"), add a parameter to the existing `search` field and branch in the selector; don't add `LibraryRecord` to the result union.
+- **Do not blend local and YouTube results in a single response.** Local-first / YouTube-fallback is a product decision, not a quirk. Mixing the two would force the client to disambiguate "is this song already in our catalog?" on every result. Keep the union and keep the all-or-nothing branch.
+- **Do not return raw `OpenStruct` from any new selector path without updating `SearchResultType.resolve_type`.** The `when OpenStruct` branch is fragile — it's only true today because the only `OpenStruct` flowing through is the YouTube payload. If you start emitting `OpenStruct` from somewhere else, dispatch will misclassify.
+- **Do not call `Song.search` outside of `Selectors::SearchResults` (or wherever the search field lives).** It's expensive — three predicates and a CASE-based ORDER BY. Other call sites that need a simpler match should use `Song.fuzzy_search` or `Song.fulltext_search` individually, or write an ILIKE.
+- **Do not paginate by `OFFSET`.** Trigram and tsvector queries can be expensive enough that `LIMIT N OFFSET M` for large M is pathological. Use keyset pagination on `(tier, score, id)` if pagination is added.
+
+## Schema invariants
+
+- The `pg_trgm` extension must remain enabled. Disabling it would break the GIN index on `songs.name`, the GiST multi-column index, and every `<%` / `<<->` operator.
+- The `immutable_array_to_string(text[], text)` SQL function must remain `IMMUTABLE`. Both the `text_search` generated column and the GiST multi-column index reference it; dropping it cascades.
+- `songs.text_search` is `GENERATED ALWAYS AS (…) STORED`. It cannot be assigned by the application. Adding to it requires dropping and recreating the column.
+- The order of `setweight` calls in the `text_search` expression encodes search-relevance priority (`A` > `B` > `C` > `D`). Changing weights is a search-behavior change, not a schema change — coordinate with whoever owns ranking quality.
+
+## Test boundary
+
+Specs owned by this feature are limited to `spec/queries/search_spec.rb`. The scope-level coverage of ranking, fuzzy matching, and the `text_search` column lives in `spec/models/song_spec.rb` under `features/songs/`. If you change ranking, update both.

--- a/autopilot-support/index/features/search/map.md
+++ b/autopilot-support/index/features/search/map.md
@@ -1,0 +1,26 @@
+# Search Functionality — Map
+
+What each file in this feature does. Paths are the canonical source; this file points at them.
+
+## GraphQL
+
+- `app/graphql/types/search_result_type.rb` — `Types::SearchResultType`. A `BaseUnion` over `SongType` and `YoutubeResultType`. `resolve_type` dispatches on Ruby class: `Song` → `SongType`, `OpenStruct` → `YoutubeResultType`. The `OpenStruct` branch is load-bearing — `YoutubeClient#search` returns `OpenStruct` (not a model), so changing that shape will break union resolution. The `search` query field itself is wired in `app/graphql/types/query_type.rb` (see `features/songs/` cross-references) and returns `[SearchResultType]`.
+
+## Selector
+
+- `app/lib/selectors/search_results.rb` — `Selectors::SearchResults`. The orchestration layer between `QueryType#search` and the data layer. Two-tier fallback: try the local Song catalog first (`from_all_songs`), and only if empty fall back to the external `YoutubeClient#search`. Excludes songs already in the caller's library via a `NOT IN (LibraryRecord.select(:song_id).where(user:))` subquery. Note: this file currently uses `Song.arel_table[:name].matches("%query%")` (a plain ILIKE on name only) — the richer 3-tier ranking lives on the `Song.search` scope in `app/models/song.rb` and is **not** invoked here. See patterns.
+
+## Database
+
+- `db/migrate/20200226234544_enable_pgtrgm_extension.rb` — Enables Postgres `pg_trgm`. Required by both the GIN trigram index on `songs.name` and the GiST trigram index on the multi-column searchable expression. Without this extension, none of the search scopes will load.
+- `db/migrate/20200226234654_add_gin_index_to_song_name.rb` — Adds the GIN index on `songs.name` using `gin_trgm_ops`. Powers fast ILIKE / `%` and `<%` operators against the name column specifically. The newer `text_search`/multi-column trigram indexes (in `features/songs/`) **do not replace** this index — name-only ILIKE still hits this one.
+
+## Tests
+
+- `spec/queries/search_spec.rb` — Request spec for the GraphQL `search` query. Pins two contracts: (1) songs already in the caller's library are filtered out; (2) when no local songs match, the YouTube fallback is invoked and its `OpenStruct` results render as `YoutubeResult`. `YoutubeClient.new` is stubbed via `instance_double` — `client_double.search(query)` is the seam.
+
+## See also (not owned by this feature)
+
+- `app/models/song.rb` — Owns the `search` / `fulltext_search` / `fuzzy_search` scopes and the `text_search` tsvector column. Lives under `features/songs/`. Patterns below explain why search scopes live on the model rather than in the selector.
+- `app/graphql/types/query_type.rb` — Defines `field :search` and `def search` that instantiates `Selectors::SearchResults`. Lives under `structures/resources.md`.
+- `db/migrate/20251117092530_add_text_search_to_songs.rb` and `db/migrate/20251117093000_add_multi_column_trigram_search.rb` — The newer text_search tsvector column and multi-column trigram GiST index. Listed under `features/songs/` because they belong to the Song schema, but the search behavior they enable is documented in patterns.

--- a/autopilot-support/index/features/search/patterns.md
+++ b/autopilot-support/index/features/search/patterns.md
@@ -1,0 +1,63 @@
+# Search Functionality — Patterns
+
+Non-obvious conventions for how search works in this app. The "what" lives in the code; this file is the "why" and "watch out for".
+
+## Search is Postgres-native — there is no Elasticsearch, OpenSearch, or external index
+
+Every search path in this app runs against the live `songs` table through SQL operators and indexes provided by the `pg_trgm` extension plus a stored `tsvector`. There is no background indexer, no document store, no out-of-band sync. If you are tempted to add Elastic / Meilisearch / Algolia, read `boundaries.md` first — the decision to stay in Postgres is intentional.
+
+## The 3-tier ranking lives on `Song`, not in the selector
+
+`Song.search` (in `app/models/song.rb`) is the canonical ranked-search scope. It UNIONs three search strategies via a single `WHERE … OR … OR …` and assigns each row a tier in the `ORDER BY`:
+
+- **Tier 1 — full-text match.** `text_search @@ plainto_tsquery(query)` against the generated `text_search` tsvector column. Ordered within the tier by `ts_rank`.
+- **Tier 2 — fuzzy trigram match.** `query <% (name || ' ' || channel_title || ' ' || tags)` using `pg_trgm`'s word-similarity operator. Ordered within the tier by `word_similarity` descending (closest first).
+- **Tier 3 — ILIKE substring fallback.** Guarantees that any literal substring of the combined searchable text returns a hit even when the tokenizer (`'english'::regconfig`) strips it (stopwords, short fragments, punctuation-adjacent tokens).
+
+A row only appears in the higher-tier set if it actually satisfies that tier's predicate; tiers 2 and 3 are recall safety nets, not re-ranks of tier 1. **The ordering shape (tier ASC, then per-tier score DESC) is what makes the contract feel like "best match first" without a heuristic global score** — don't replace the CASE with a weighted sum.
+
+## The `text_search` column is generated, weighted, and indexed by a separate migration
+
+`db/migrate/20251117092530_add_text_search_to_songs.rb` declares `text_search` as `GENERATED ALWAYS AS (…) STORED`. The expression composes four `setweight` calls in priority order:
+
+- `'A'` — `name`
+- `'A'` — `channel_title`
+- `'B'` — `youtube_tags`
+- `'C'` — `description`
+
+Postgres maintains this column on every write to `songs` — application code never assigns it. The GIN index `index_songs_on_text_search` is what makes `@@ plainto_tsquery(…)` fast. If you add a new searchable column on `Song`, you must roll a new migration that drops and recreates `text_search`; you cannot `ADD COLUMN` to a generated column.
+
+## The `immutable_array_to_string` SQL function exists only to make `youtube_tags` indexable
+
+`array_to_string` is `STABLE`, not `IMMUTABLE`, which means it can't appear inside a generated column or a functional index. The migration defines a hand-rolled SQL wrapper marked `IMMUTABLE` to bypass this. It's referenced by both the `text_search` generated column and the GiST trigram index on the combined searchable expression. **Do not delete or rewrite this function** — every search index depends on it.
+
+## Two trigram indexes exist for two different operators
+
+- `index_songs_on_name` (GIN, `gin_trgm_ops`) — powers ILIKE / `%` / `<%` against `songs.name` **only**. Added by `db/migrate/20200226234654_add_gin_index_to_song_name.rb`.
+- `index_songs_on_searchable_content_trgm` (GiST, `gist_trgm_ops`) — powers fuzzy operators (`<%`, `<<->`) against the combined `name || channel_title || tags` expression. Added by `db/migrate/20251117093000_add_multi_column_trigram_search.rb`.
+
+GIN is faster for read, slower for write; GiST supports `<<->` distance ordering, which GIN does not. Both are kept because the queries that hit them are different.
+
+## The selector currently bypasses the 3-tier scope
+
+`Selectors::SearchResults#from_all_songs` calls `Song.where(Song.arel_table[:name].matches("%#{query}%"))` — a plain ILIKE on `name` only. It does not invoke `Song.search` and therefore does not get tsvector ranking, fuzzy fallback, or multi-column matching. The richer scopes on `Song` are tested in `spec/models/song_spec.rb` (under `features/songs/`) and are evidently intended to be wired into this selector. **If you "fix" the selector to call `Song.search`, also re-confirm the library-exclusion subquery and the no-result branch in `spec/queries/search_spec.rb`** — that spec currently asserts behavior consistent with the ILIKE path.
+
+## Library-exclusion subquery — not a join
+
+The selector uses `where.not(id: LibraryRecord.select(:song_id).where(user: user))`, which Rails compiles to a `NOT IN (SELECT …)`. This is correlated against the caller's `LibraryRecord` rows. It's intentionally not a `LEFT OUTER JOIN … WHERE library_records.id IS NULL` because the result set returns plain `Song` rows and we never want to JOIN-multiply the relation across library records. If you change this to a join, deduplicate explicitly.
+
+## Local-first, YouTube-fallback ordering is product-driven
+
+`#search` returns local songs if **any** match (`from_all_songs.present?`), otherwise falls back to the external YouTube search. Local and YouTube results are never blended in the same response. This is what makes `Types::SearchResultType` a union — clients have to handle both possible shapes, but only one is ever returned per query.
+
+## The `OpenStruct` branch in `resolve_type` is load-bearing
+
+`YoutubeClient#search` returns `OpenStruct` instances (not models, not POROs). `SearchResultType.resolve_type` dispatches on `Song` vs `OpenStruct`. If you ever turn the YouTube payload into a real class (e.g., `YoutubeResult.new(...)`), update the union resolver in lockstep — otherwise GraphQL will return null types and clients will see empty results without an error.
+
+## `lookahead` is plumbed but unused
+
+`Selectors::SearchResults#initialize` accepts a `lookahead:` and stores it; nothing reads it. `QueryType#search` passes `extras: [:lookahead]` to opt in. This is a hook for future N+1 prevention — if you eager-load associations conditional on requested fields, do it in the selector by inspecting `@lookahead.selects?(:field_name)`.
+
+## Empty query short-circuits in two places
+
+Both `QueryType#search` (`return [] if query.blank?`) and `Song.search` (`return none if query.blank?`) defensively return empty. The selector itself does not. This means a blank query never hits the database — and never hits the YouTube client either, which is what you want (YouTube's search API will gladly return its top videos for an empty string and silently exhaust quota).

--- a/autopilot-support/index/features/songs/boundaries.md
+++ b/autopilot-support/index/features/songs/boundaries.md
@@ -1,0 +1,22 @@
+# Song Library — Boundaries
+
+## Extension points
+- New YouTube-sourced metadata fields plug in by adding a column migration (mirroring `db/migrate/20200415022511_add_youtube_details_to_songs.rb`), extending `SongCreate#attrs_from_youtube!`, and exposing the field on `Types::SongType`. If the field should be searchable, it must also be added to the generated `text_search` column — drop and recreate via a new migration; you cannot `ALTER` a GENERATED column's expression in place.
+- New search modes belong on the `Song` model as additional named scopes alongside `fulltext_search` / `fuzzy_search` / `search`. Keep them parameter-shape compatible (`->(query)`) so callers can swap them. Reuse the `searchable_expr` pattern (qualified column names + `COALESCE`) when fuzzy/ILIKE matching across multiple columns.
+- Tier composition lives entirely in `Song.search`; if a fourth tier or a different ranking is needed, change it in one place — callers do not need to know.
+- Re-hydrating stale YouTube metadata (if ever needed) belongs in a worker that calls `YoutubeClient` and updates Songs in bulk — not in `SongCreate`, which is deliberately one-shot.
+
+## Do-not-build
+- Do not add per-user state (added_at, position, source, listen counts, favorited) to `songs`. That state belongs on `LibraryRecord` — see **music-library**. The `songs` table must stay global and user-agnostic.
+- Do not call YouTube from this feature. All YouTube HTTP/parsing lives in `app/lib/youtube_client.rb` (the **youtube** feature). `SongCreate` only knows the method `YoutubeClient#find`.
+- Do not add a unique DB index on `youtube_id`. The current `find_or_initialize_by` flow tolerates the non-unique index and is relied on by callers (recommendation accept, library add) that race on the same id. Promoting the index to unique would surface as `RecordNotUnique` in those flows.
+- Do not validate or transform metadata fields (name, description, etc.) — they are YouTube's truth, written verbatim. Validations would break re-attach of pre-existing rows where YouTube has since updated a title.
+- Do not write to `Song` outside `SongCreate` for the create path. Tests use `create(:song, ...)` to skip YouTube, but production code should not.
+
+## Where Song Library ends
+- The `LibraryRecord` join, library deletion, and library population logic are **music-library**, not here. `Song` is unaware of who owns it.
+- `Tag` / `TagLibraryRecord` association live in **tagging**. Songs surface tags only via the `youtube_tags` array (YouTube-supplied), which is distinct from user-applied tags.
+- `Recommendation` create / accept flows are **recommendations**. They call `SongCreate` to land the song, then build their own join rows.
+- Search result wrapping (`SearchResultType`, multi-model search) lives in **search**. This feature owns the SQL primitives; **search** assembles the user-facing query.
+- YouTube HTTP, video parsing, and quota concerns are **youtube** (`app/lib/youtube_client.rb`).
+- Room-level "current song" coupling is on `rooms` (`current_song_id`, `current_song_start` — see `db/migrate/20190407020627_add_song_data_to_room.rb`), owned by **real-time-playback** and **rooms**, not here.

--- a/autopilot-support/index/features/songs/map.md
+++ b/autopilot-support/index/features/songs/map.md
@@ -1,0 +1,23 @@
+# Song Library — Map
+
+## Model
+- `app/models/song.rb` — `Song` AR model. Validates `youtube_id` presence. Owns three search scopes (`fulltext_search`, `fuzzy_search`, `search`) built on the `text_search` tsvector generated column plus a pg_trgm fallback. Has many `library_records` and (through) `users`.
+
+## GraphQL
+- `app/graphql/mutations/song_create.rb` — `Mutations::SongCreate`. `find_or_initialize_by(youtube_id:)`, fetches metadata via `YoutubeClient` only on first insert, then attaches a `LibraryRecord` for the caller. Optional `from_user_id` argument stamps the record as `source: "saved_from_history"`.
+- `app/graphql/types/song_type.rb` — `Types::SongType`. Exposes YouTube-sourced metadata fields and the back-reference to `library_records`. `youtube_id` and `licensed` are non-null; most metadata is nullable because it is populated asynchronously from YouTube.
+
+## Migrations
+- `db/migrate/20190218202341_create_song.rb` — Initial table (UUID id, `name`, `url`, `room_id`). The `url` and `room_id` columns no longer exist (see follow-up migrations).
+- `db/migrate/20190305135026_add_duration_in_seconds_to_songs.rb` — Adds `duration_in_seconds` (populated from YouTube metadata at create time, not user input).
+- `db/migrate/20190322022735_remove_room_from_song.rb` — Drops `room_id`; songs are global, not per-room.
+- `db/migrate/20190322030217_add_index_to_songs.rb` — Indexes `youtube_id` (non-unique). Uniqueness is enforced by the `find_or_initialize_by` pattern in `SongCreate`, not by a DB constraint.
+- `db/migrate/20190326121153_update_song_table.rb` — Replaces `url` with `description`.
+- `db/migrate/20190407020627_add_song_data_to_room.rb` — Adds `current_song_id` / `current_song_start` to `rooms` (caller-side, not on songs).
+- `db/migrate/20200226234654_add_gin_index_to_song_name.rb` — Adds the pg_trgm GIN index on `songs.name` used by fuzzy/ILIKE search.
+- `db/migrate/20200415022511_add_youtube_details_to_songs.rb` — Adds `thumbnail_url`, `license`, `licensed`, `youtube_tags` (string array, default `[]`).
+
+## Specs
+- `spec/factories/song.rb` — Minimal `:song` factory; only `name` and `youtube_id` are seeded. YouTube-derived fields are left nil unless tests set them explicitly.
+- `spec/models/song_spec.rb` — Relationship coverage plus the `.search` contract: name/prefix/channel/description/tag matching, ranking by ts_rank, fuzzy fallback for substring queries, nil-safety.
+- `spec/mutations/song_create_spec.rb` — Documents the create-vs-reattach behavior, the `YoutubeClient` stubbing convention, and the `from_user_id` source-stamping path. Also pins the empty-`youtube_id` error string.

--- a/autopilot-support/index/features/songs/patterns.md
+++ b/autopilot-support/index/features/songs/patterns.md
@@ -1,0 +1,29 @@
+# Song Library — Patterns
+
+## Identity is `youtube_id`
+- A Song is uniquely identified by its `youtube_id`. There is no DB unique constraint; uniqueness is enforced at the application layer via `Song.find_or_initialize_by(youtube_id: ...)` in `Mutations::SongCreate#resolve`.
+- The `youtube_id` index (see `db/migrate/20190322030217_add_index_to_songs.rb`) exists to make that lookup cheap, not to enforce uniqueness. Adding songs through any path other than `SongCreate` risks duplicates.
+- `youtube_id` is the only `presence` validation on the model; everything else (name, description, duration, channel, tags) is YouTube-sourced and nullable.
+
+## YouTube metadata is hydrated once, at create time
+- `SongCreate#attrs_from_youtube!` only fires when the Song was just initialized (`unless song.persisted?`). Existing songs are never re-hydrated, even if YouTube data has changed.
+- The hydration writes `description`, `duration_in_seconds`, `name`, `thumbnail_url`, `youtube_tags`, `channel_title`, `channel_id`, `published_at`, `category_id` in one `update!`. All of these come from `YoutubeClient#find` — there is no user-supplied path for any of them.
+- `duration_in_seconds` is therefore authoritative-from-YouTube; do not expose it as a mutation input.
+
+## Three-tier search (`Song.search`)
+- The `text_search` column is a Postgres GENERATED tsvector (see `db/migrate/20251117092530_add_text_search_to_songs.rb`) with weighted fields: name and channel_title at weight A, youtube_tags at B, description at C. The migration also defines an `immutable_array_to_string` SQL function — required because `array_to_string` is not immutable enough for a generated column.
+- `Song.search(q)` ORs three conditions and orders by tier:
+  1. Full-text match against `text_search` (uses the GIN index on `text_search`), ordered by `ts_rank`.
+  2. pg_trgm word_similarity (`<%` / `<<->`) over a `COALESCE`-joined expression of name + channel_title + tags.
+  3. ILIKE substring over the same expression — guarantees a contains match even when the first two miss.
+- `Song.fulltext_search` and `Song.fuzzy_search` are exposed separately for callers that want only one tier. `search` is the default; the spec pins its recall/ranking behavior.
+- The `searchable_expr` deliberately qualifies column names with `songs.` to avoid ambiguity when scopes are chained from other tables.
+
+## Library attachment is part of `SongCreate`
+- `SongCreate` is not just a Song factory — it always (re)attaches the caller to the song via `LibraryRecord.find_or_initialize_by(song:, user: context[:current_user])`. Callers that need a Song without a library effect should not use this mutation.
+- The optional `from_user_id` argument records attribution (`source: "saved_from_history"`, `from_user_id: ...`) only on the first attachment. Subsequent calls for an existing record do not overwrite source — the spec asserts this preserves the original "I added this myself" attribution.
+- This is why `SongCreate` is the entry point used by recommendation acceptance and library-add flows: it idempotently produces (Song, LibraryRecord) without re-fetching YouTube.
+
+## Test scaffolding
+- `YoutubeClient` is always stubbed in `SongCreate` specs (`instance_double(YoutubeClient)`); the spec also asserts it is *not* called for existing songs — that absence is part of the contract.
+- The model spec uses raw `create!` rather than the factory when exercising `.search`, so it can pin the exact field combinations against the weighted tsvector. The factory leaves YouTube-derived columns blank, which would make search assertions ambiguous.

--- a/autopilot-support/index/features/tagging/boundaries.md
+++ b/autopilot-support/index/features/tagging/boundaries.md
@@ -1,0 +1,20 @@
+# Music Tagging — Boundaries
+
+## Extension points
+- New tag metadata (color, icon, description, ordering): add columns to the `tags` table and expose on `Types::TagType`. The validation surface is intentionally minimal — extend on `Tag` and the mutation will keep working without changes if the field is optional.
+- New tag-side queries (list a user's tags, filter library records by tag) belong on `current_user.tags` / `tag.library_records` — the associations are already in place; the missing piece is a query field, not a model change.
+- Bulk operations beyond add/remove (rename, merge, delete) can be added as sibling mutations next to `tag_create.rb` / `tag_toggle.rb`. Keep ownership enforcement via `current_user.tags.find_by(...)` — that pattern is the de facto authorization check for tag-scoped mutations.
+- DB-level uniqueness on `[tag_id, library_record_id]` lets new callers safely use `insert_all` / `upsert_all` without app-level dedup. Preserve that index when adding columns to the join.
+
+## Do-not-build
+- Don't tag `Song` directly. The previous schema (`tags_songs`) was migrated away from for a reason: tagging is per-user, and songs are global. Route any "tag this track" intent through the user's `LibraryRecord` — create the library record first if needed (see **music-library**).
+- Don't introduce global, team-scoped, or shared tags through this feature. The data model has no notion of tag visibility; bolting it on with a nullable `user_id` or a `team_id` column will silently break `TagToggle`'s `current_user.tags.find_by(...)` authorization. Sharing requires a real design pass.
+- Don't add `validates_uniqueness_of` on `TagLibraryRecord`. The unique index already enforces it and is the canonical check; an AR validation would race and add no safety.
+- Don't add AR callbacks to `TagLibraryRecord` expecting them to fire from `TagToggle`. The mutation uses `insert_all`/`delete_all` to stay cheap; any callback-driven side-effect needs to move into the mutation itself.
+- Don't make `TagToggle` distinguish "tag not found" from "tag belongs to another user." The collapsed error is intentional non-enumeration.
+
+## Where tagging ends
+- `LibraryRecord` (the user-song join), its lifecycle, and its association back to `Tag` belong to **music-library**. This feature owns the tag side of the join only.
+- `Song` (the YouTube-backed track) belongs to **songs**. Tagging never references songs directly at runtime; only the 2020-05-13 migration touches `song_id` and only to backfill.
+- Tag-driven filtering, fuzzy tag search, or tag autocomplete belong to **search** (or a future feature) — `TagType` exposes nothing query-shaped today.
+- The `User` and `current_user` plumbing comes from **user-authentication**; tagging consumes `current_user` but does not own it.

--- a/autopilot-support/index/features/tagging/map.md
+++ b/autopilot-support/index/features/tagging/map.md
@@ -1,0 +1,22 @@
+# Music Tagging — Map
+
+## Models
+- `app/models/tag.rb` — User-owned tag. `belongs_to :user`; `has_many :library_records, through: :tag_library_records`. Only validation is `name` presence.
+- `app/models/tag_library_record.rb` — Join between `Tag` and `LibraryRecord`. Sets `self.table_name = "tags_library_records"` because the literal table name is plural-plural (the legacy `tags_songs` from initial migrations was renamed in place, not regenerated).
+
+## GraphQL
+- `app/graphql/mutations/tag_create.rb` — Mints a new `Tag` scoped to `current_user`. Returns `errors` array on invalid; the only failure mode wired in spec is blank `name`.
+- `app/graphql/mutations/tag_toggle.rb` — Bulk add/remove of `tag <-> library_record` joins for a single `tag_id`. Re-scopes the tag through `current_user.tags.find_by(...)` so cross-user toggles surface as `"Tag must be present"`. Uses `TagLibraryRecord.insert_all` for adds and `.delete_all` for removes — no AR callbacks fire.
+- `app/graphql/types/tag_type.rb` — Exposes `id`, `name`, `user`, and `library_records`. No song-level field; songs are reached via library records.
+
+## Migrations
+- `db/migrate/20200304014052_create_tags_table.rb` — Creates `tags` (uuid PK), `user_id`, `name`. Indexes `user_id` only.
+- `db/migrate/20200304014747_create_tags_songs.rb` — Original join table `tags_songs` (tag_id, song_id). Superseded by the rename below; keep in mind when reading old data dumps.
+- `db/migrate/20200401223702_add_unique_tags_songs_index.rb` — Adds the uniqueness guarantee on the join, originally on `[tag_id, song_id]`. The successor unique index lives on the renamed table.
+- `db/migrate/20200513040509_allow_library_record_to_associate_to_tags.rb` — Pivots the join from songs to library records: backfills `library_record_id` per row by looking up `LibraryRecord` from `(tag.user_id, song_id)`, drops `song_id`, recreates the unique index on `[tag_id, library_record_id]`, and renames `tags_songs` -> `tags_library_records`. Defines a throwaway `TagSong` constant inline. `down` is intentionally irreversible.
+
+## Specs
+- `spec/factories/tag.rb` — Trivial factory; default name `"jam city"`, requires associated `user`.
+- `spec/models/tag_spec.rb` — Covers `belongs_to :user` and the `library_records` through-association.
+- `spec/mutations/tag_create_spec.rb` — Request-level happy path + blank-name error. Asserts `libraryRecords` is empty on a freshly minted tag.
+- `spec/mutations/tag_toggle_spec.rb` — Add/remove combo in one call, plus two ownership/missing-tag error cases (uuid not found, tag owned by another user) — both return `"Tag must be present"` and do not mutate the join table.

--- a/autopilot-support/index/features/tagging/patterns.md
+++ b/autopilot-support/index/features/tagging/patterns.md
@@ -1,0 +1,18 @@
+# Music Tagging — Patterns
+
+## Tags are user-scoped, not global or team-scoped
+- A `Tag` `belongs_to :user`. There is no `team_id`, no shared/global flag, and no visibility model. Two users in the same team have independent tag namespaces — name collisions are allowed and meaningful (each user's `"chill"` is a different row).
+- `TagCreate` always assigns `user: current_user`. `TagToggle` re-scopes through `current_user.tags.find_by(id: tag_id)` before doing any work, so authorization is enforced by the scope, not by a separate check. Passing another user's `tag_id` returns the same `"Tag must be present"` error as a missing id — by design, no leak between the two cases.
+
+## Tags attach to LibraryRecords, not Songs
+- The join lives between `Tag` and `LibraryRecord`. A user can only tag songs that are already in their library — tagging implicitly requires library membership.
+- The original `tags_songs` table was renamed in place to `tags_library_records` (see the 2020-05-13 migration). `TagLibraryRecord` carries an explicit `self.table_name` because the Rails-default name for the class would be `tag_library_records` (singular-plural), not the actual `tags_library_records` (plural-plural).
+- The migration backfills `library_record_id` via `LibraryRecord.find_by(user_id: tag.user_id, song_id: ...)` — confirming the invariant that a tag's owner and the joined library record's owner are the same user. Nothing in the runtime code re-asserts that invariant; it's structural.
+
+## Uniqueness is a DB-level guarantee
+- The unique index on `[tag_id, library_record_id]` is the source of truth — there is no AR `validates_uniqueness_of` and no `find_or_create_by` in `TagToggle`. `insert_all` would raise on a conflict, so callers (the client) are expected to send sane `add_ids`.
+- `TagToggle` uses `insert_all` and `delete_all` — both skip callbacks and validations. If callbacks ever get added to `TagLibraryRecord` they will not fire here.
+
+## Two-mutation split
+- `TagCreate` only mints the tag; it never attaches it to a record. `TagToggle` never creates a tag; it only mutates joins. The client is expected to chain them when creating-and-applying in one user action.
+- `TagToggle` takes both `addIds` and `removeIds` in a single call so the client can drive a multi-select toggle UI in one round trip; partial failures aren't modeled (the two arrays run sequentially with no transaction wrapper).

--- a/autopilot-support/index/features/teams/boundaries.md
+++ b/autopilot-support/index/features/teams/boundaries.md
@@ -1,0 +1,26 @@
+# Team Collaboration — Boundaries
+
+## Extension points
+
+### New team-level fields
+- Add columns to `teams` via a new migration, expose them on `app/graphql/types/team_type.rb`, and — if they should reach connected clients — extend the GraphQL string in `app/workers/broadcast_team_worker.rb`. The worker's query is the canonical team-channel payload; `TeamType` fields not listed there will not appear in broadcasts.
+- For team-scoped settings, consider whether the value lives on `Team` (single source of truth) or on the `teams_users` join (per-member settings). The join is currently bare; promoting it to an attributed model is the right move if you need per-membership state.
+
+### New team mutations
+- New mutations should derive scope from `current_user.active_team`, not from a `team_id` argument. `TeamActivate` is the only mutation that takes a `team_id` and it does so to switch context. Other mutations should read context, not accept it.
+- If a new flow needs to broadcast, call `BroadcastTeamWorker.perform_async(team_id)` after persisting, the same way `TeamActivate` does.
+
+## Do not build
+
+- **Do not bypass `team_users` for membership.** Always go through `user.teams <<` / `team.users <<` (the `has_many :through` macros). Direct `TeamUser.create!` calls are technically possible but skip the association cache and complicate test setup; nothing in the codebase does this today.
+- **Do not bake team-scoping into individual mutations.** Resolve the team from `current_user.active_team` rather than accepting a `team_id` argument. Forcing every client call to pass a team id reopens auth questions the activation step has already settled.
+- **Do not hand-roll an auth check against `team.users`.** Use `current_user.teams.exists?(id:)` (as `TeamActivate` does); it is shorter and uses the through-association without loading user records.
+- **Do not extend `TeamType` and assume clients will see it on the channel.** The broadcast payload is governed by the GraphQL string inside `BroadcastTeamWorker`, not the type definition.
+- **Do not add a second `belongs_to` for owner with a different name.** `Team#owner` is the only owner concept; renaming it or layering a co-owner relation should be discussed first since `TeamCreate` and several specs encode the single-owner assumption.
+
+## Where teams end
+
+- **Rooms** belong to a team (`rooms.team_id`), but the room lifecycle (creation, activation, ownership) lives in `features/rooms/`. The teams feature only knows that rooms hang off a team and that the broadcast worker nests them into the team payload.
+- **User invitations** — onboarding users into an existing team is the invitation feature's responsibility. `TeamCreate` handles the *initial* owner sign-up only; subsequent member onboarding lives in `features/user-invitations/`.
+- **Authentication and the Doorkeeper token returned by `TeamCreate`** are owned by `features/user-authentication/`. The `access_token_for` helper and the Devise validations the mutation relies on are documented there.
+- **`User#active_room_id`** mirrors the active-team pattern but belongs to `features/rooms/`; the teams feature only owns `active_team_id`.

--- a/autopilot-support/index/features/teams/map.md
+++ b/autopilot-support/index/features/teams/map.md
@@ -1,0 +1,30 @@
+# Team Collaboration — Map
+
+## Models
+- `app/models/team.rb` — Team root; `belongs_to :owner` (User), `has_many :rooms`, and `has_many :users, through: :team_users`. Owner is just an FK column on `teams`, not a join.
+- `app/models/team_user.rb` — Join model for the `teams`/`users` many-to-many. Pins `self.table_name = "teams_users"` because the underlying table uses the legacy plural-plural Rails name.
+
+## GraphQL — Types
+- `app/graphql/types/team_type.rb` — Public `Team` type exposing `id`, `name`, `rooms`, and `users`. No mutation-side fields; team membership is read through this surface.
+
+## GraphQL — Mutations
+- `app/graphql/mutations/team_create.rb` — Creates a team plus (find-or-create) owner user in one call, attaches the owner to the team, and returns a Doorkeeper access token. Overrides `ready?` to skip the default auth (this is a sign-up surface). `TeamOwnerInputObject` is defined inline as a nested input.
+- `app/graphql/mutations/team_activate.rb` — Sets `current_user.active_team_id`. Authorizes by checking `current_user.teams.exists?(id:)` before flipping, then fans out broadcasts to the previous and the newly active team.
+
+## ActionCable
+- `app/channels/team_channel.rb` — Broadcasts per-team state to subscribers. Rejects subscription when `current_user.active_team` is nil; streams keyed by the user's currently active team object.
+
+## Workers
+- `app/workers/broadcast_team_worker.rb` — Sidekiq worker on the `broadcast_team` queue. Re-executes a hard-coded GraphQL team query under `override_current_user: true` and pushes the result to `TeamChannel.broadcast_to(Team.find(team_id), ...)`. Called from `TeamActivate` for both the previous and the newly active team.
+
+## Migrations
+- `db/migrate/20191231014000_create_teams.rb` — Creates `teams` with UUID PK, `name`, and `owner_id` (no FK constraint).
+- `db/migrate/20191231014524_add_team_to_room.rb` — Adds `team_id` UUID column to `rooms`; rooms-belong-to-team is wired here, not in a teams-side migration.
+- `db/migrate/20191231015122_create_teams_users.rb` — Creates the join table under the legacy plural-plural name `teams_users` (UUIDs, indexes on both FKs, timestamps).
+- `db/migrate/20191231020447_add_active_team_to_users.rb` — Adds `active_team_id` UUID column to `users` to track the user's current team context.
+
+## Specs
+- `spec/factories/team.rb` — `:team` factory; auto-creates an owner via `create(:user)`. No `users` association is built — tests append via `team.users <<` or `create(:user, teams: [team])`.
+- `spec/models/team_spec.rb` — Relationship coverage: owner FK, users via the join, and rooms-belong-to-team (creating rooms with `team:` keyword).
+- `spec/mutations/team_activate_spec.rb` — Covers success (switching active team across two teams) and the "not a member" rejection. Demonstrates the `create(:user, teams: [team])` factory pattern.
+- `spec/mutations/team_create_spec.rb` — Covers new-user and existing-user team creation (including case-insensitive email match) and the two failure paths (bad password for existing user, insecure password for new user). Note the `describe` string is misleadingly named "Invitation Create".

--- a/autopilot-support/index/features/teams/patterns.md
+++ b/autopilot-support/index/features/teams/patterns.md
@@ -1,0 +1,25 @@
+# Team Collaboration — Patterns
+
+## Team lifecycle: create vs. activate
+- `TeamCreate` is a public surface (overrides `ready?` to bypass auth) used as a combined sign-up + team-creation entry point. It find-or-creates the owner user via `ensure_user!`, creates the `Team`, then appends `team_owner.teams << team`. The mutation returns a Doorkeeper access token, not a `Team` field — the client is expected to log in with that token and resolve the team separately.
+- `TeamCreate` does not call `BroadcastTeamWorker`. There are no team-channel subscribers at the moment of creation, so the broadcast happens later when the user activates the team.
+- `TeamActivate` is the only path that mutates `users.active_team_id`. Membership is enforced through `current_user.teams.exists?(id: team_id)` — do not assume callers have already authorized.
+
+## The `teams_users` join (legacy plural-plural)
+- The DB table is named `teams_users` (both sides plural), the older Rails naming convention. `TeamUser` explicitly pins `self.table_name` to that string; renaming the model or table breaks the association.
+- Membership is added through the `has_many :through` macros (`user.teams << team` / `team.users << user`) — the `TeamUser` model itself is rarely instantiated directly. Specs and `TeamCreate` both use the through-association append form.
+- The join carries no extra columns (just `team_id`, `user_id`, timestamps). Adding a role or per-membership setting would mean upgrading the join into a real attributed model.
+
+## `active_team_id` as current-team context
+- `User.active_team` (declared in `app/models/user.rb` as `belongs_to :active_team, optional: true, foreign_key: :active_team_id, class_name: "Team"`) is the implicit "current team" for the rest of the app. It is `optional`, so newly-created users start with no active team.
+- `TeamChannel#subscribed` reads `current_user.active_team` directly — if the user has not yet called `teamActivate`, subscription is rejected. The team channel is therefore unusable until activation has happened at least once.
+- The activation flow broadcasts to *both* the previous and the new team so clients subscribed to either channel see the membership/state transition.
+
+## Broadcast fan-out via `BroadcastTeamWorker`
+- The worker re-executes a hard-coded GraphQL query (`team(id:) { rooms { ... users { ... } } }`) inside Sidekiq using `MusicboxApiSchema.execute` with `context: { override_current_user: true }`. This is the standard pattern for workers that need to render GraphQL payloads without a real request user — the schema's auth layer honors that context flag.
+- The payload shape is fixed inside the worker, not driven by the subscribed client. Adding a new field to the team-channel payload means editing the GraphQL string in `BroadcastTeamWorker#query`, not changing `TeamType`.
+- Broadcast key is the `Team` instance (`TeamChannel.broadcast_to(Team.find(team_id), ...)`) so streams are scoped per team record.
+
+## Rooms attach to a team via column, not association on Team
+- The team↔room link is owned by `Room` through the `team_id` column added in `20191231014524_add_team_to_room.rb`. `Team` only declares `has_many :rooms`; the inverse `belongs_to :team` and any room-side validations live in `features/rooms/`.
+- The room broadcast payload is rendered by the team broadcast worker (rooms are nested under `team { rooms { ... } }` in the worker's query) — so room-list changes propagate to clients through the team channel, not a dedicated room-list channel.

--- a/autopilot-support/index/features/user-authentication/boundaries.md
+++ b/autopilot-support/index/features/user-authentication/boundaries.md
@@ -1,0 +1,51 @@
+# User Authentication & Management — Boundaries
+
+What this feature owns, where it ends, and what not to build inside it.
+
+## What this feature owns
+
+- The `User` model's auth surface: Devise modules, password hashing, `valid_password?`, `valid_for_authentication?`, `reset_password`, and `start_password_reset!`.
+- Doorkeeper configuration and the OAuth password-grant flow (token issuance, validation, `current_user` lookup from `resource_owner_id`).
+- The `users`/`oauth_*` table schemas.
+- `Mutations::UserUpdate` and `Mutations::UserPasswordUpdate`.
+- `Types::UserType` (the public projection of a User).
+- `UsersChannel` (presence broadcast for the room) and `BroadcastUsersWorker`.
+- `NotAuthenticatedError` and its rescue path.
+
+## Where this feature ends
+
+- **Invitations and onboarding** — Anything that *creates* a `User` (acceptance tokens, the `Invitation` model, `invited_user_name`, `EmailInvitationWorker`) is `features/user-invitations/`. This feature treats the `User` row as already existing.
+- **Password reset** — The mailer-driven flow (`EmailPasswordResetWorker`, the reset-by-token mutation) is `features/password-reset/`. This feature owns `start_password_reset!` on the model but not the flow that calls it. `Mutations::UserPasswordUpdate` (changing a password while logged in) stays here; `Mutations::PasswordReset*` (anonymous, token-bearing) does not.
+- **Teams and memberships** — `Team`, `TeamUser`, `team_users`/`teams` associations, team activation, and `active_team_id` mechanics live in `features/teams/`. This feature only declares the `has_many :teams, through: :team_users` association on `User` because `User` is its home class.
+- **Rooms and active-room logic** — `active_room`/`active_room_id`, room joining/leaving as a domain concept, and the `room` table itself live in `features/rooms/`. `UsersChannel#unsubscribed` clearing `active_room_id` lives here because it is the *presence-of-the-User* edge, but the meaning of `active_room` belongs to rooms.
+- **Library, tags, playlists, listens** — All `User`-rooted associations (`library_records`, `songs`, `tags`, `room_playlist_records`) are owned by their respective feature directories.
+
+## Extension points
+
+- **New Devise module** — Add to the `devise` line in `app/models/user.rb`; add a migration adding any required columns; update the commented-out blocks in `db/migrate/20190329051901_add_devise_to_users.rb` mentally (don't backfill the old migration). Confirm `valid_for_authentication?` semantics still match — see Patterns.
+- **Account lock without `:lockable`** — Override `active_for_authentication?` on `User`. Token issuance in `config/initializers/doorkeeper.rb` already routes through `valid_for_authentication?` and will silently refuse tokens for inactive users.
+- **A new updatable user field** — Add the column migration, add the `argument :field, …` line to `UserUpdateInputObject` in `app/graphql/mutations/user_update.rb`, and add the corresponding `hsh[:field] = user[:field] if user[:field].present?` inside `update_with`. Also add the field to `app/graphql/types/user_type.rb` if it should be readable.
+- **A new auth strategy** — Add a Doorkeeper grant flow in `config/initializers/doorkeeper.rb` (`grant_flows`) and implement the matching block (`authorization_code` → set `resource_owner_authenticator`). All three `current_user` resolvers (`ApplicationController`, `BaseMutation`/`QueryType` via context, `ApplicationCable::Connection`) work off `Doorkeeper::AccessToken`, so they require no change. For something that is *not* a Doorkeeper token (e.g., signed JWT, API key), all three resolvers must be touched.
+- **Forcing a logout** — Revoke the user's `Doorkeeper::AccessToken` rows (set `revoked_at`). No app-side code exists for this — add a mutation under this feature if needed, and reuse `current_user.access_grants`/`access_tokens` via the Doorkeeper associations.
+
+## Do not build here
+
+- **Custom session middleware / cookies / CSRF for the API.** The app is `ActionController::API` (`app/controllers/application_controller.rb`), there is no session store, and `clean_up_csrf_token_on_authentication` is irrelevant. Authentication is bearer-token only — do not add a cookie path.
+- **A user registration mutation under this feature.** Sign-up belongs to `features/user-invitations/` (invitation-only). If product direction changes and open sign-up is added, create a new feature directory rather than reviving `:registerable`.
+- **A `confirm_email` flow.** `:confirmable` is intentionally not enabled and no `confirmation_token` column exists.
+- **A `current_user` resolver that bypasses Doorkeeper.** Don't read raw bearer tokens, don't decode JWTs, don't query `oauth_access_tokens` directly. Go through `doorkeeper_token` in controllers and `Doorkeeper::AccessToken.by_token` in `ApplicationCable::Connection`.
+- **Calling `set_reset_password_token` directly from anywhere outside `User`.** It is protected on purpose; go through `User#start_password_reset!`.
+- **Mutations or services that mass-assign to `User`.** `Mutations::UserUpdate` is whitelist-only on purpose; preserve that pattern.
+- **Broadcasting from a mutation under this feature using `override_current_user: true`.** The flag is honored by queries (`QueryType#confirm_current_user!`) but not by mutations (`BaseMutation` always requires auth). Re-broadcast via a worker, not a server-side mutation call.
+- **Devise mailers.** `config.mailer = "Devise::Mailer"` is set but unused — outbound email goes through Mailgun workers under `features/password-reset/` and `features/user-invitations/`. Do not wire `ActionMailer` SMTP into this feature.
+
+## Schema invariants
+
+- `users.id` is `uuid`. So is `oauth_access_tokens.resource_owner_id` and `oauth_access_grants.resource_owner_id`. Any new auth table referencing a user must use `t.uuid :user_id` (or `t.references :user, type: :uuid`).
+- `users.email` has a unique index; Devise downcases and strips whitespace on write.
+- `users.reset_password_token` has a unique index; reset tokens are single-use across all users.
+- Doorkeeper's `oauth_access_tokens.token` and `refresh_token` both carry unique indexes.
+
+## Test boundary
+
+Specs for this feature live in `spec/{models,mutations,queries,workers}/user*` and `spec/factories/users.rb`. The cross-cutting `spec/support/auth_helper.rb` is documented in `structures/testing.md` and **is not in this feature** — it provides the `Doorkeeper::AccessToken.create!` shortcut used by every other feature's request specs, so changes there ripple everywhere.

--- a/autopilot-support/index/features/user-authentication/map.md
+++ b/autopilot-support/index/features/user-authentication/map.md
@@ -1,0 +1,62 @@
+# User Authentication & Management — Map
+
+Every file in scope for this feature, per `feature_classification.csv` (`Feature == "User Authentication & Management"`). One line per file, pointing at its role.
+
+## Model
+
+- `app/models/user.rb` — `User` is the Devise resource (`:database_authenticatable, :recoverable, :validatable`) and the OAuth resource owner; exposes `start_password_reset!` as the public alias for Devise's protected `set_reset_password_token`. All other associations (`active_room`, `active_team`, `library_records`, `team_users`/`teams`, `tags`, `room_playlist_records`) are owned by other features but hang off this class.
+
+## GraphQL — mutations
+
+- `app/graphql/mutations/user_password_update.rb` — `Mutations::UserPasswordUpdate` verifies the old password via `valid_password?` then calls Devise's `reset_password(new, new)` to set the new one; returns `errors: ["Invalid password"]` or `errors: ["Insecure password"]`. No `user` field returned.
+- `app/graphql/mutations/user_update.rb` — `Mutations::UserUpdate` accepts a `UserUpdateInputObject` and only updates `:name` today; uses the internal `update_with` whitelist pattern so new fields require explicit handling (no mass-assignment).
+
+## GraphQL — types
+
+- `app/graphql/types/user_type.rb` — `Types::UserType` (graphql_name `"User"`) — public user surface: `id`, `email`, `name`, `active_room`, `active_team`, `teams`. Password/Devise internals are deliberately not exposed.
+
+## Channels
+
+- `app/channels/users_channel.rb` — `UsersChannel` — clears `active_room` on `unsubscribed` (browser close / network drop) and enqueues `BroadcastTeamWorker` so other clients see the user leave the room.
+
+## Workers
+
+- `app/workers/broadcast_users_worker.rb` — `BroadcastUsersWorker` (queue `broadcast_users`) — re-runs a hardcoded `room.users { id name email }` query through `MusicboxApiSchema.execute` with `context: { override_current_user: true }` to bypass auth, then broadcasts the result on `UsersChannel` keyed by `Room`.
+
+## Lib
+
+- `app/lib/not_authenticated_error.rb` — `NotAuthenticatedError`. Raised by `Mutations::BaseMutation#prepare_response` and `QueryType#confirm_current_user!`, rescued in `GraphqlController#execute` and rendered as HTTP 401.
+
+## Initializers
+
+- `config/initializers/devise.rb` — case-insensitive + whitespace-stripped `:email`, bcrypt stretches of 11 (1 in test), password length `6..128`, reset window `6.hours`. Mailer is wired to `Devise::Mailer` but the app does not actually use it (password reset emails go out via `EmailPasswordResetWorker` through Mailgun, not Devise mailers).
+- `config/initializers/doorkeeper.rb` — `grant_flows %w[password]` only (Resource Owner Password Credentials Grant); `access_token_expires_in nil` (tokens never expire); `resource_owner_from_credentials` looks up by email via `User.find_for_database_authentication` and gates on `valid_for_authentication?` so `active_for_authentication?` can veto. The `resource_owner_authenticator` block raises — there is no web sign-in flow.
+
+## Migrations
+
+- `db/migrate/20180115152059_create_users.rb` — original `users` table with just `email`, `name` on a `uuid` id; pre-Devise.
+- `db/migrate/20190329051317_create_doorkeeper_tables.rb` — first Doorkeeper schema, integer ids.
+- `db/migrate/20190329051721_drop_user_table.rb` — wipes the original users table to make room for the Devise rebuild.
+- `db/migrate/20190329051901_add_devise_to_users.rb` — recreates `users` with `uuid` id and Devise columns (`encrypted_password`, `reset_password_token/_sent_at`, `remember_created_at`). Commented-out blocks for `:trackable`, `:confirmable`, `:lockable` show what was deliberately skipped.
+- `db/migrate/20190329055527_drop_doorkeeper.rb` — drops the integer-id Doorkeeper tables.
+- `db/migrate/20190329055638_recreate_doorkeeper_with_uuids.rb` — recreates `oauth_applications`, `oauth_access_grants`, `oauth_access_tokens` with `uuid` ids and `resource_owner_id` typed as `uuid` to match `users`.
+- `db/migrate/20190403034154_add_room_and_name_to_user.rb` — adds `name` (back) and `room_id` to users.
+- `db/migrate/20200423152618_remove_remember_at_from_user.rb` — drops `remember_created_at`; `:rememberable` is not in the Devise module list, so the column was dead weight.
+
+## Factories
+
+- `spec/factories/users.rb` — `factory :user` — email is `"anime-turtle-#{SecureRandom.uuid}@myspace.com"` (unique per build), password is the literal `"hunter2"`. Filename is plural; the factory itself is singular (`:user`).
+
+## Specs
+
+- `spec/models/user_spec.rb` — relationship-only model spec (per repo convention; no validation/callback specs).
+- `spec/mutations/user_password_update_spec.rb` — request-type spec for `UserPasswordUpdate`; covers invalid-old-password, weak-new-password, and happy-path login-with-new-password.
+- `spec/mutations/user_update_spec.rb` — request-type spec for `UserUpdate`; asserts the whitelist (only `name` updates).
+- `spec/queries/user_spec.rb` — request-type spec for the `currentUser` query (and what fields render).
+- `spec/workers/broadcast_users_worker_spec.rb` — worker-type spec; asserts the broadcast payload on `UsersChannel`.
+
+## Cross-references (NOT in this feature)
+
+- `app/controllers/application_controller.rb#current_user` and `app/controllers/graphql_controller.rb` — request-side auth glue; lives under structures, not this feature.
+- `app/channels/application_cable/connection.rb` — channel-side auth; same.
+- `spec/support/auth_helper.rb` — test helper; covered in `structures/testing.md`.

--- a/autopilot-support/index/features/user-authentication/patterns.md
+++ b/autopilot-support/index/features/user-authentication/patterns.md
@@ -1,0 +1,61 @@
+# User Authentication & Management — Patterns
+
+Non-obvious conventions used across this feature. The "what" lives in the code; this file is the "why" and "watch out for".
+
+## Devise modules in use (and the ones missing)
+
+`User` declares only `:database_authenticatable, :recoverable, :validatable`. Notable omissions: no `:registerable` (sign-up is not a Devise route — users are created either through invitation acceptance in `features/user-invitations/` or by tests/seeds), no `:rememberable` (the `remember_created_at` column was removed by `db/migrate/20200423152618_remove_remember_at_from_user.rb`), no `:trackable`, no `:confirmable`, no `:lockable`, no `:timeoutable`. The commented-out schema blocks in `db/migrate/20190329051901_add_devise_to_users.rb` document this intentionally.
+
+## OAuth: password grant only, tokens never expire
+
+`config/initializers/doorkeeper.rb` enables exactly one grant flow: `grant_flows %w[password]` (Resource Owner Password Credentials). Clients POST `username` + `password` to the Doorkeeper-mounted `/api/v1/oauth/token` endpoint (see `use_doorkeeper` in `config/routes.rb`) and receive a bearer token. `access_token_expires_in nil` — tokens never expire. There is no refresh-token logic in this app; nothing calls `use_refresh_token`. Sign-out, on the client, just means discarding the token.
+
+## How Devise and Doorkeeper hand off
+
+`resource_owner_from_credentials` in `config/initializers/doorkeeper.rb` calls `User.find_for_database_authentication(email: params[:username])` (a Devise method) and then `user.valid_for_authentication? { user.valid_password?(params[:password]) }`. The `valid_for_authentication?` wrapper is what runs Devise's `active_for_authentication?` hook chain — if a future module (or override) returns false from `active_for_authentication?`, token issuance silently fails (returns nil = invalid credentials response). This is the canonical extension point to lock accounts without adding `:lockable`.
+
+## `current_user` resolution: three separate code paths
+
+1. **HTTP / GraphQL** — `app/controllers/application_controller.rb#current_user` reads `doorkeeper_token` (set by Doorkeeper from the `Authorization: Bearer …` header) and finds the user by `resource_owner_id`. `GraphqlController#execute` stuffs that into `context: { current_user: … }` before invoking the schema. **It does not raise if missing.**
+2. **GraphQL inside the schema** — auth is enforced lazily, at field resolution, not at the controller:
+   - Mutations: `Mutations::BaseMutation#prepare_response` raises `NotAuthenticatedError` when `context[:current_user].blank?`. Every mutation inherits this.
+   - Queries: `QueryType#confirm_current_user!` raises `NotAuthenticatedError` unless `current_user` is present. Every public query field calls `confirm_current_user!` explicitly as its first line — there is no global `before_action`.
+3. **ActionCable** — `app/channels/application_cable/connection.rb` reads the token from `request.query_parameters[:token]` (because WebSocket clients can't set `Authorization` headers in browsers) and calls `reject_unauthorized_connection` when the lookup fails. The token in the URL ends up in server logs — keep that in mind when debugging.
+
+These three paths share `Doorkeeper::AccessToken` as the storage but do not share a resolver. Don't try to DRY them.
+
+## The `override_current_user` context flag
+
+Broadcast workers (including `BroadcastUsersWorker`) re-execute the schema server-side with `context: { override_current_user: true }`. `QueryType#confirm_current_user!` checks this flag and returns early; mutations inherit `BaseMutation` and **do not** honor the flag — so workers may only run queries, not mutations. If you add a new public query field, copy the `confirm_current_user!` line in; do not assume it's inherited.
+
+## `NotAuthenticatedError` lifecycle
+
+Defined in `app/lib/not_authenticated_error.rb` as a bare `StandardError`. Raised by `BaseMutation` and `QueryType` (above). Rescued in `GraphqlController#execute` and rendered as `status: 401` with no body — clients pattern-match on the HTTP status, not on a GraphQL error payload. This is why the response shape for "not logged in" and a GraphQL parse error look completely different.
+
+## Password update goes through `reset_password`, not `update`
+
+`Mutations::UserPasswordUpdate` calls Devise's `reset_password(new, new)` — note that this is *not* the recoverable token-based reset; when called directly it just runs the password-strength validations and saves. This is why the error string for a weak password is `"Insecure password"` (the boolean return of `reset_password`) rather than the model's validation messages. If you need to surface real Devise errors, you must change to `update(password: …, password_confirmation: …)` and read `current_user.errors`.
+
+## `UserUpdate` is whitelist-only
+
+`Mutations::UserUpdate#update_with` rebuilds a hash from scratch, copying only fields it explicitly enumerates. Adding a new updatable field requires both adding the `argument` to `UserUpdateInputObject` and adding a line inside `update_with`. There is no automatic mass-assignment.
+
+## Email uniqueness and casing
+
+`config/initializers/devise.rb` sets `case_insensitive_keys = [:email]` and `strip_whitespace_keys = [:email]`. Devise downcases and strips the column on every write — so the DB row will not contain the input verbatim. `users.email` has a unique index added by `db/migrate/20190329051901_add_devise_to_users.rb`; uniqueness is enforced both by `validatable` and by Postgres.
+
+## bcrypt cost is environment-specific
+
+`config.stretches = Rails.env.test? ? 1 : 11`. The factory password `"hunter2"` only encrypts in milliseconds because of this — do not assume production hashing speed from test runs.
+
+## `users` table is UUID, but the migration history is a graveyard
+
+The current schema came from three migrations in sequence — create with no Devise, drop, then recreate with Devise on a `uuid` id. The Doorkeeper tables were similarly recreated to switch `resource_owner_id` from integer to `uuid`. Treat `db/migrate/20190329051721_*` and `db/migrate/20190329055527_*` (the two `drop_*` migrations) as historical artifacts — never roll back past them, and read `db/structure.sql` for the live shape.
+
+## `UsersChannel#unsubscribed` is the "user left" signal
+
+There is no explicit "leave room" mutation. The browser disconnecting from the channel is the trigger: `UsersChannel#unsubscribed` clears `current_user.active_room` and fires `BroadcastTeamWorker`. If you add a server-side path to forcibly remove a user from a room, replicate this two-step (clear `active_room`, broadcast) rather than calling `unsubscribed` directly.
+
+## `start_password_reset!` exists so `features/password-reset/` can call `set_reset_password_token`
+
+`Devise::Recoverable#set_reset_password_token` is `protected`. `User#start_password_reset!` exists only to expose it to external callers (the password-reset mutation). Don't inline the protected method elsewhere — go through `start_password_reset!` and add behavior to that single method if needed.

--- a/autopilot-support/index/features/user-invitations/boundaries.md
+++ b/autopilot-support/index/features/user-invitations/boundaries.md
@@ -1,0 +1,23 @@
+# User Invitations — Boundaries
+
+## Where this feature ends
+
+- **User identity belongs to `user-authentication`.** `Mutations::InvitationAccept` calls into Devise (`User.find_for_database_authentication`, `valid_for_authentication?`, `valid_password?`) and `Mutations::BaseMutation#access_token_for` (Doorkeeper). When the invite flow has an "auth question" — what counts as a valid password, how access tokens are minted, how `current_user` is resolved — that lives in the user-authentication feature, not here.
+- **Team membership belongs to `teams`.** `invited_user.teams << invite.team` writes to the `teams_users` join managed by the teams feature. The locking strategy (`with_lock`) is local to this mutation, but the join model, its uniqueness rules, and the `active_team` concept are owned by teams.
+- **Mailgun delivery mechanics are shared.** `EmailInvitationWorker` and `EmailPasswordResetWorker` are sibling implementations of the same Mailgun-direct-HTTP pattern. The `"a mailgun worker"` shared example in `spec/workers/email_worker_shared_examples.rb` is the contract; treat changes to the HTTP shape as a cross-feature concern.
+
+## Extension points
+
+- **New invitation states.** The `invitation_state` enum lives on `Invitation` and is the single place to add values like `expired` or `revoked`. Anything new needs a backing column value (string, not integer — the enum maps to strings), the enum entry, a transition trigger (probably a new mutation or a worker), and updates to `Mutations::InvitationCreate#ensure_complete_invite!`, which currently has explicit logic only for `accepted` and `pending`.
+- **New delivery channels.** Replace or wrap `EmailInvitationWorker` enqueuing in `Mutations::InvitationCreate#send_invite!`. Keep the contract narrow: the worker takes an `invitation_id` and is responsible for everything else. Any new channel worker (SMS, Slack, etc.) should land on its own queue, not piggyback on `email_invitations`.
+- **Token strategy.** `Invitation.token` is the one chokepoint for token generation. Swap implementations there; do not inline random-token code at call sites. The column is `uuid`, so changing format requires a migration.
+- **Email payload shape.** `EmailInvitationWorker#request` builds the `h:X-Mailgun-Variables` JSON blob. Adding or renaming variables also requires updating the Mailgun-side `invitation` template, which is not in this repo — coordinate.
+
+## Do not build
+
+- **Do not reinvent token logic in callers.** `Mutations::InvitationCreate` calls `Invitation.token`. Do not call `SecureRandom.uuid` directly from mutations or workers — the model class method is the seam tests stub against.
+- **Do not bypass the worker for delivery.** Even in synchronous paths, send via `EmailInvitationWorker.perform_async`. Tests use `have_enqueued_sidekiq_job` to assert the enqueue happened; direct sends would break that contract and skip Sidekiq retries on Mailgun failures.
+- **Do not add a `before_create` token callback.** The current pattern is explicit assignment in the mutation. Adding a callback would make the existing specs' `expect(Invitation).to receive(:token)` stubs fragile and would mask the "already pending — reuse token" branch.
+- **Do not add a uniqueness validation on `email + team`.** The idempotency is enforced by `find_or_initialize_by`, not by a DB constraint. Adding a uniqueness rule would turn the re-invite path into a validation failure rather than a silent reuse. If you need DB-level safety, prefer a partial unique index over a model validation.
+- **Do not expire invitations from inside this feature.** There is currently no expiry concept. If one is needed, add it as a state transition driven by a clock job (the project uses `clockwork` / Sidekiq), not as a query-time check.
+- **Do not return enumeration-leaking errors from `InvitationAccept`.** The current `"Invalid invitation"` error is the same for "no such email" and "no such token" — keep it that way, mirroring the password-reset feature's no-leak convention.

--- a/autopilot-support/index/features/user-invitations/map.md
+++ b/autopilot-support/index/features/user-invitations/map.md
@@ -1,0 +1,38 @@
+# User Invitations — Map
+
+Token-based invite flow: an authenticated user invites an email to their active team, an email goes out via Mailgun, the recipient accepts to either create a new user or attach to an existing one and join the team.
+
+## Model
+
+- `app/models/invitation.rb` — `Invitation` AR record. Holds `email`, `name`, `token`, `invitation_state`, and the inviter/team association. Defines `Invitation.token` (UUID generator) and the `invitation_state` enum.
+
+## GraphQL
+
+- `app/graphql/types/invitation_type.rb` — `Invitation` GraphQL type. Exposes `email`, `name`, `invitation_state`, `inviting_user`, `invited_user`, and `team`.
+- `app/graphql/mutations/invitation_create.rb` — `Mutations::InvitationCreate`. Authenticated. `find_or_initialize_by(email, team)` idempotency, mints a token only when missing, enqueues `EmailInvitationWorker`.
+- `app/graphql/mutations/invitation_accept.rb` — `Mutations::InvitationAccept`. Public (overrides `ready?`). Looks up by `(email, token)`, creates-or-authenticates the user, joins them to the team, flips state to `:accepted`, returns an access token.
+
+(Read-side resolvers live in `app/graphql/types/query_type.rb` — `invitation(token:, email:)` and `invitations` — but that file is shared with every other feature and lives in `structures/resources.md`, not here.)
+
+## Worker
+
+- `app/workers/email_invitation_worker.rb` — Sidekiq worker on the `email_invitations` queue. POSTs to Mailgun's `mg.musicbox.fm/messages` endpoint using the `invitation` template; raises `EmailInvitationWorker::DeliveryError` on non-2xx.
+
+## Migrations
+
+- `db/migrate/20191231155941_create_invitations.rb` — initial table. `id: :uuid`, `token` indexed, `invited_by_id` is the inviter FK (note the column name diverges from the association name).
+- `db/migrate/20200102170036_add_state_to_invitation.rb` — adds `invitation_state` string column (backs the enum).
+- `db/migrate/20200209060935_add_invited_user_name_to_invitation.rb` — adds `name` column for the invitee's display name (used by the email template and the GraphQL type).
+
+## Specs
+
+- `spec/models/invitation_spec.rb` — relationship coverage (`inviting_user`, `invited_user` by email match, `team`), `Invitation.token` delegation to `SecureRandom`, and enum state assignment.
+- `spec/mutations/invitation_create_spec.rb` — request specs covering idempotency (same email/team re-invite reuses token), separate-team uniqueness, no state reset on already-accepted, and the unauthenticated-rejection case.
+- `spec/mutations/invitation_accept_spec.rb` — request specs covering new-user creation, existing-user team attachment (case-insensitive email match), duplicate-team no-op, invalid email/token, failed auth for an existing user, and weak-password rejection.
+- `spec/queries/invitation_spec.rb` — request spec for the public `invitation(email:, token:)` query.
+- `spec/workers/email_invitation_worker_spec.rb` — uses the `"a mailgun worker"` shared example to assert the Mailgun POST body.
+
+## Notes on what is NOT here
+
+- No factory exists for `Invitation` (`spec/factories/` has none); every spec builds invitations with `Invitation.create!` inline. Tracked as a known gap in `structures/testing.md`.
+- No mailer ERB templates live in the repo — the email body is a server-side Mailgun template referenced by name (`invitation`).

--- a/autopilot-support/index/features/user-invitations/patterns.md
+++ b/autopilot-support/index/features/user-invitations/patterns.md
@@ -1,0 +1,51 @@
+# User Invitations — Patterns
+
+## Token generation lives on the model class
+
+`Invitation.token` is a class method, not a callback. Callers (`Mutations::InvitationCreate#ensure_complete_invite!`) explicitly assign `invite.token = Invitation.token` when the field is blank. This is why the model spec stubs `SecureRandom.uuid` against `described_class.token` and why `invitation_create_spec.rb` stubs `Invitation.token` directly — there is no `before_create` to mock around.
+
+The `token` column is `uuid` (see the create migration) and is indexed. There is no uniqueness constraint, but the GraphQL query uses `(token, email)` as the lookup pair so collision-on-token alone would not cross-leak invites.
+
+## Idempotent create via (email, team)
+
+`Mutations::InvitationCreate` uses `find_or_initialize_by(email: email.downcase, team: current_user.active_team)`. Implications:
+
+- Re-inviting the same address for the same team reuses the existing row and the existing token, but still re-enqueues the worker — so the existing recipient gets another email with the same link.
+- The same email across different teams creates separate invitations, each with its own token (covered by the "allows a new invitation for a different team" spec).
+- An already-`accepted` invitation is never reset back to `pending` — `ensure_complete_invite!` guards with `unless invite.accepted?`. The worker still re-enqueues regardless; nothing prevents resending the email for an accepted invite.
+- Email is lowercased on write. The accept path does not lowercase its lookup, but downstream `User.find_for_database_authentication` is case-insensitive (Devise default).
+
+## Email delivery is direct HTTP to Mailgun, not ActionMailer
+
+`EmailInvitationWorker` does not use ActionMailer — it builds a `Net::HTTP::Post` to `https://api.mailgun.net/v3/mg.musicbox.fm/messages` and basic-auths with `ENV["MAILGUN_KEY"]`. The body is `set_form_data` with `template: "invitation"` plus `h:X-Mailgun-Variables` carrying `inviter_name`, `team_name`, `token`, and a URI-encoded `email`. Consequence: there is no `app/views/mailers/` for this email — the template lives in the Mailgun account.
+
+Non-2xx responses raise `EmailInvitationWorker::DeliveryError`, which surfaces as a Sidekiq retry.
+
+The shared spec example `"a mailgun worker"` is defined in `spec/workers/email_worker_shared_examples.rb` and is used by both this worker and `EmailPasswordResetWorker` — that file is the canonical place to assert "this worker posts the right Mailgun payload."
+
+## `invited_user` is an email-keyed association, not a FK
+
+`Invitation` belongs to `invited_user` via `foreign_key: :email, primary_key: :email, class_name: "User", optional: true`. There is no `invited_user_id` column. Implications:
+
+- The GraphQL `Invitation.invitedUser` field lights up automatically the instant a `User` with that email exists, regardless of whether the invitation was ever accepted. The invitation spec exercises this: it creates the user *after* the invitation and the association still resolves.
+- Email is the join key on both sides, so case differences would break the link. `User#email` is normalized by Devise; `Invitation#email` is lowercased on create by the mutation.
+
+## `inviting_user` uses a column name that diverges from the association
+
+`belongs_to :inviting_user, foreign_key: :invited_by_id, class_name: "User"`. The database column is `invited_by_id` (set in the original create migration); the Ruby association is `inviting_user`. Selectors and queries that hand-write SQL should use `invited_by_id`; everywhere else, use the association.
+
+## Acceptance state machine
+
+The `invitation_state` enum has exactly two values: `pending` and `accepted`. There is no `expired`, `revoked`, or `declined`. Lifecycle:
+
+1. `Mutations::InvitationCreate` sets state to `:pending` (unless already accepted) when minting or re-using the row.
+2. `Mutations::InvitationAccept` calls `update!(invitation_state: :accepted)` inside `finalize_invitation!`. The state flip is the *last* step — user creation and team join run first; if either fails the state stays `pending`. The team-membership step is wrapped in `invited_user.with_lock` to avoid duplicate `teams_users` rows under concurrent acceptances.
+3. There is no expiry check anywhere — a pending invitation is valid forever until accepted.
+
+## Public mutation, but enforced lookup
+
+`InvitationAccept` overrides `ready?` to return `true`, so it runs without `context[:current_user]`. The "authorization" is structural: the resolver does `Invitation.find_by(email:, token:)` and returns `{ errors: ["Invalid invitation"] }` on miss. Both fields are required for the lookup, so possession of just one is not enough.
+
+## Team linkage at accept time
+
+The invitation already knows its `team` from creation. Acceptance does `invited_user.teams << invite.team` (the `teams_users` join is owned by the teams feature, not this one). The `unless invited_user.teams.exists?(id: invite.team.id)` guard makes duplicate accepts a no-op for membership purposes — but the state still flips to `:accepted` and an access token still mints, so the mutation is effectively idempotent for an already-on-team user.

--- a/autopilot-support/index/features/youtube/boundaries.md
+++ b/autopilot-support/index/features/youtube/boundaries.md
@@ -1,0 +1,44 @@
+# YouTube Integration — Boundaries
+
+What this feature owns, where it ends, and what not to build inside it.
+
+## What this feature owns
+
+- `app/lib/youtube_client.rb` — the only HTTP integration with the YouTube Data API.
+- `app/graphql/types/youtube_result_type.rb` — the GraphQL projection of a search result.
+- The schema-level YouTube columns added by `db/migrate/20190319122943_add_youtube_id_to_songs.rb` and `db/migrate/20200415022511_add_youtube_details_to_songs.rb`. Those columns physically live on `songs` (owned by `features/songs/`), but the *shape* — what gets pulled from YouTube, what the names are — is owned here.
+- The `ENV["YOUTUBE_KEY"]` contract (see `.env.template`).
+
+## Where this feature ends
+
+- **Song persistence and identity** — `Song` model, `youtube_id` as primary external key, `Mutations::SongCreate`, and the hydration call site (`attrs_from_youtube!`) all belong to `features/songs/`. This feature provides `YoutubeClient#find` and the shape of its return value; it does not own how those fields land in the database.
+- **Search UI integration** — `Selectors::SearchResults#from_youtube`, `Types::SearchResultType` (the union), the `search` query field, and the local-first/YouTube-fallback policy live in `features/search/`. This feature owns `YoutubeClient#search` and `Types::YoutubeResult`; it does not own where they get composed into the search response.
+- **Recommendations** — `Mutations::RecommendationCreate` takes a `youtube_id` argument and looks up `Song.find_by(youtube_id:)`, but never instantiates `YoutubeClient`. Recommendation flows belong to `features/recommendations/`.
+- **Library and listening history** — Anything keyed on a `Song` after it exists (LibraryRecord, RecordListen, tagging) is downstream of this feature.
+
+## Extension points
+
+- **New YouTube endpoints** — Add a method to `YoutubeClient` (e.g., `playlist_items`, `channel`, `comments`). Mirror the existing pattern: build the params hash with `key: ENV["YOUTUBE_KEY"]`, call `get`, and shape the response into an `OpenStruct` or array of `OpenStruct`s. Pick a return-shape convention up front — see Patterns on how `find` and `search` deliberately diverge.
+- **Alternative providers (SoundCloud, Spotify, Bandcamp)** — Add a sibling class in `app/lib/` (e.g., `SoundcloudClient`) with the same constructor shape (`initialize(user)`). Do not add provider branching inside `YoutubeClient`. The Song model is currently single-provider (`youtube_id` is the identity); a multi-provider Song requires schema work in `features/songs/` first.
+- **Per-user quota or OAuth-tokened access** — The unused `@user` field on `YoutubeClient` is the hook. Add reads of `@user.youtube_access_token` (or similar) inside `find`/`search`. Today every caller already passes `current_user`, so the call sites do not need to change.
+- **Real error handling** — Wrap the body of `YoutubeClient#get` (or add a higher-level rescue around `find`/`search`) to call `Airbrake.notify` on non-success. Coordinate with the call sites: `SongCreate` currently has no fallback for `find` returning `nil`, and adding one belongs there, not here.
+- **A `videoId → metadata` cache** — Caller's concern. See "Do not build here" below.
+
+## Do not build here
+
+- **Calling YouTube from controllers, mutations, channels, or workers directly.** Every YouTube call must go through `YoutubeClient`. Today there are exactly two call sites (`Mutations::SongCreate` and `Selectors::SearchResults`). Adding a third should still instantiate `YoutubeClient.new(current_user)` — do not inline `Net::HTTP`, do not use `URI.open`, and do not pull in a Google SDK.
+- **Caching at this layer.** No `Rails.cache.fetch`, no memoization across instances, no ETag handling. If `Mutations::SongCreate` were called twice in quick succession, that is the caller's problem to solve (and `Song.find_or_initialize_by(youtube_id:)` already solves it at the persistence layer). For `search`, the caller (`SearchResults`) is the right place to decide on caching since it also owns the local-first policy.
+- **Per-request rate limiting or quota tracking.** YouTube enforces it server-side; the client surfaces failures as `nil`/`[]`. Quota awareness belongs in operational dashboards, not in this code path.
+- **Adding `Airbrake.notify` inline in `YoutubeClient#get`** without also fixing `SongCreate#attrs_from_youtube!`. Notifying and then letting `SongCreate` raise a `NoMethodError` on `video.description` is worse than the current behavior — coordinate the two changes.
+- **A "refresh YouTube metadata" job.** Song hydration is intentionally single-shot at create time (see `features/songs/patterns.md`). If product wants drift correction, design it as a feature with its own boundaries, not as a bolt-on to `YoutubeClient`.
+- **Reusing `Types::YoutubeResult` for non-search payloads.** Its four-field shape exists to mirror `YoutubeClient#search` output. Use a new type for any other YouTube projection, or surface `Song` fields directly via `Types::SongType`.
+- **A separate `YoutubeSearchType`, `YoutubeVideoType`, etc.** Today's surface is one search type. Resist proliferation — adding fields to `YoutubeResult` is cheaper than adding sibling types.
+
+## Schema invariants
+
+- `songs.youtube_id` is a `string`, indexed but **not** uniquely constrained (`db/migrate/20190322030217_add_index_to_songs.rb`). Uniqueness is enforced at the application layer via `find_or_initialize_by` — see `features/songs/`. New tables referencing a video by YouTube ID should use `string`, not foreign-key to `songs.id`, if they want to represent unknown-yet videos.
+- `songs.youtube_tags` is `string[]` with `default: []`. Treat empty array and `nil` differently only if you have a reason to — `YoutubeClient#find` will write whatever the API returned (which may be a `nil` if `:tags` is absent on the snippet).
+
+## Test boundary
+
+- No dedicated spec for `YoutubeClient` itself — it has no test coverage. The two callers stub it (`spec/mutations/song_create_spec.rb`, indirectly `spec/queries/search_spec.rb`), so behavior changes to `YoutubeClient` will not be caught by CI. If you change response shape, grep for `YoutubeClient` and update every stub.

--- a/autopilot-support/index/features/youtube/map.md
+++ b/autopilot-support/index/features/youtube/map.md
@@ -1,0 +1,14 @@
+# YouTube Integration — Map
+
+## Client
+
+- `app/lib/youtube_client.rb` — `YoutubeClient`. Thin wrapper over YouTube Data API v3 (`videos` and `search` endpoints) using raw `Net::HTTP`. Reads `ENV["YOUTUBE_KEY"]`. Two public methods: `find(youtube_id)` (hydration for `SongCreate`) and `search(query)` (search-before-add UX). Accepts a `user` in the constructor but never uses it — kept for future per-user quota/auth.
+
+## GraphQL surface
+
+- `app/graphql/types/youtube_result_type.rb` — `Types::YoutubeResult`. Projects a `YoutubeClient#search` result (`id`, `name`, `description`, `thumbnail_url`) for the client's search-before-add UI. All fields are non-null even though `YoutubeClient#search` populates them from optional API fields — empty strings will pass, missing keys will raise. Returned as one of the `Types::SearchResultType` union members (see `features/search/`).
+
+## Schema
+
+- `db/migrate/20190319122943_add_youtube_id_to_songs.rb` — Adds `songs.youtube_id` (string). The string-typed external key used everywhere as the song's identity.
+- `db/migrate/20200415022511_add_youtube_details_to_songs.rb` — Adds `songs.thumbnail_url`, `license`, `licensed` (default `false`), `youtube_tags` (string array, default `[]`). These are the YouTube-sourced columns hydrated by `SongCreate` via `YoutubeClient#find`; they live on `Song` (see `features/songs/`).

--- a/autopilot-support/index/features/youtube/patterns.md
+++ b/autopilot-support/index/features/youtube/patterns.md
@@ -1,0 +1,35 @@
+# YouTube Integration — Patterns
+
+## Raw `Net::HTTP`, no SDK, no gem
+
+- `YoutubeClient` uses `Net::HTTP` directly — there is no `google-api-client`, Faraday, or HTTParty in the loop. Responses are parsed with `JSON.parse(..., symbolize_names: true)`, so all reads use symbol keys (`:items`, `:snippet`, `:contentDetails`, `:thumbnails`). If you swap in a different transport, preserve symbol-keyed dig paths or update every caller.
+- The two endpoints are hard-coded URLs (`https://www.googleapis.com/youtube/v3/videos` and `.../search`). The `key` is `ENV["YOUTUBE_KEY"]` (see `.env.template`). No base-URL/config object exists.
+
+## Failures are silently swallowed
+
+- `YoutubeClient#get` returns `nil` for any non-`Net::HTTPSuccess` response. There is no retry, no exception, no `Airbrake.notify`, no logging — quota exhaustion, network errors, and 4xx from a bad key all look identical to "no results."
+- `find` returns `nil` when the API returns no items; `search` returns `[]`. Neither caller (`Mutations::SongCreate#attrs_from_youtube!` and `Selectors::SearchResults#from_youtube`) checks for `nil`. `SongCreate` will then raise a `NoMethodError` on `video.description` if `find` returns `nil` — there is no defensive guard, by design or by oversight.
+- Despite `config/initializers/airbrake.rb` being configured, this client does not opt in. Failures will surface only through the resulting Rails exception (in `SongCreate`) or as an empty search result (in `SearchResults`).
+
+## `find` vs `search` shape divergence
+
+- `find(youtube_id)` returns a rich `OpenStruct` with nine fields including `duration` (ISO-8601 parsed via `ActiveSupport::Duration.parse(...).to_f` — seconds as float), `youtube_tags`, `channel_*`, `published_at`, `category_id`. These map directly to the columns hydrated by `SongCreate#attrs_from_youtube!`.
+- `search(query)` returns an `OpenStruct` array with only four fields (`id`, `name`, `description`, `thumbnail_url`) — matching `Types::YoutubeResult` exactly. The `id` is `videoId`, not the wrapper `id` object. Do not assume `find` and `search` results are interchangeable.
+- Field names also diverge: `find` produces `title`, `search` produces `name`. The mismatch is intentional — `find` mirrors the API payload, `search` mirrors the GraphQL projection.
+
+## Hydration is single-shot, at create time
+
+- `YoutubeClient#find` is called exactly once per song, inside `Mutations::SongCreate#attrs_from_youtube!`, guarded by `unless song.persisted?`. There is no refresh job, no re-hydration path, no migration to backfill — once written, fields are frozen. See `features/songs/patterns.md`.
+- This is why `YoutubeClient` does not cache: the only call site is already idempotent at the Song-row level.
+
+## Search fallback ordering
+
+- `Selectors::SearchResults#search` queries the local `Song` table first (substring `ILIKE` on `name`, excluding songs already in the user's library) and only falls back to `YoutubeClient#search` when local results are empty. Quota is spent only on novel queries. This is owned by `features/search/`; documented here to explain why `YoutubeClient#search` traffic is low and asymmetric.
+
+## `user` parameter is dead weight (for now)
+
+- `YoutubeClient.new(user)` stores the user on `@user` but never reads it. Both callers pass the current user out of habit. If you add per-user quotas, OAuth-tokened YouTube access, or audit logging, this is the hook.
+
+## Test convention
+
+- `spec/mutations/song_create_spec.rb` stubs the client with `instance_double(YoutubeClient)` and asserts `YoutubeClient` is *not* instantiated for already-persisted songs — that absence is part of the contract. No spec exercises the real HTTP path.

--- a/autopilot-support/index/structures/data-model.md
+++ b/autopilot-support/index/structures/data-model.md
@@ -1,0 +1,90 @@
+# Data Model
+
+Authoritative schema lives in `db/structure.sql` (the project uses structure.sql, not schema.rb — see commit `8a9a086`). All tables use `uuid` primary keys (`gen_random_uuid()`). This doc captures the non-obvious shape of the domain; consult the model files in `app/models/` for behavior and `db/structure.sql` for column-level truth.
+
+## Domain in one paragraph
+
+Users belong to Teams (many-to-many via `teams_users`). Each Team has many Rooms. A Room is the listening session: it plays through an ordered queue of `RoomPlaylistRecord` rows (each pointing at a `Song`). As a record plays, `RecordListen` rows capture each listener's reaction. Users build personal libraries of songs via `LibraryRecord` (with optional recommendation flow between users), and tag those library entries with personal `Tag`s through the `tags_library_records` join. Invitations onboard new users into a Team.
+
+## Models
+
+### `User` — `app/models/user.rb`
+- Devise: `database_authenticatable`, `recoverable`, `validatable` (so `users.email`, `encrypted_password`, `reset_password_token` are Devise-owned).
+- Two "active session" pointers on the user row itself: `active_room_id` and `active_team_id` (both optional `belongs_to` back to `Room`/`Team`). These represent which room/team the user is currently focused on — surprising because they live on `users`, not on a session table.
+- `has_many :library_records` is **scoped to exclude `pending_recommendation` source** (with explicit NULL handling because Postgres `!=` excludes NULLs). Anyone querying `user.songs` or `user.library_records` is implicitly filtering out pending recommendations — use `LibraryRecord.where(user: user)` directly to see them.
+- `start_password_reset!` exposes Devise's protected `set_reset_password_token` for explicit invocation.
+- Hot lookups: unique index on `users.email`, unique index on `reset_password_token`, index on `active_room_id` (see `db/structure.sql`).
+
+### `Team` — `app/models/team.rb`
+- Required `owner` (`belongs_to :owner, class_name: "User"` via `owner_id`) — every team has exactly one owning user. No validation in the model; relies on DB-level association.
+- `has_many :rooms`, `has_many :users, through: :team_users`.
+
+### `TeamUser` — `app/models/team_user.rb`
+- Join table for `Team` <-> `User`. Note the explicit `self.table_name = "teams_users"` (Rails would default to `team_users`; the DB uses the pluralized form `teams_users`).
+- Indexes on both `team_id` and `user_id` in `db/structure.sql`.
+
+### `Room` — `app/models/room.rb`
+- Belongs to a `Team`. Hosts the playback state machine:
+  - `current_record` (`belongs_to :current_record, class_name: "RoomPlaylistRecord"`) — the song currently playing.
+  - `current_song` (`has_one :current_song, through: :current_record, source: :song`) — convenience shortcut.
+  - `playing_until` — timestamp when the current song ends (indexed; see `index_rooms_on_playing_until` — this is the hot path for the playback worker that finds rooms whose songs have finished).
+  - `queue_processing` (default `false`) — guard flag while the queue is being advanced.
+  - `waiting_songs` — boolean signaling there are no queued songs.
+  - `user_rotation` — `uuid[]` column on `rooms`. Drives DJ-rotation order for queue picking; surprising because it's a Postgres array, not a join table.
+- `Room#idle!` clears `current_record`, `playing_until`, `queue_processing`, and `waiting_songs` (the "room is empty / nothing playing" state).
+- `Room#playing_record!(record)` sets `current_record`, computes `playing_until` from `record.song.duration_in_seconds.seconds.from_now`, and clears `queue_processing`.
+- `has_many :users, foreign_key: :active_room_id` — the inverse of `User#active_room`; lists users currently focused on this room.
+
+### `RoomPlaylistRecord` — `app/models/room_playlist_record.rb`
+- The queue row: one `Song` queued by one `User` in one `Room`. Has an `"order"` integer column (quoted because `order` is a SQL reserved word).
+- `enum :play_state, { played: "played", waiting: "waiting" }` — string-backed enum. Drives the "what's still in the queue vs what's been played" split. Indexed on `play_state` and `played_at` (timestamps when the record actually played). Also indexed on `room_id`, `song_id`, `user_id` — heavily-queried join target.
+- `has_many :record_listens`.
+
+### `RecordListen` — `app/models/record_listen.rb`
+- One row per (record, song, user) — represents a user's reaction to a specific play of a specific song in a queue. Has an `approval` integer column (default `0`) which is **not** modeled as a Rails enum but is treated as one upstream (likely values like -1/0/1 for skip/neutral/up; check resolvers).
+- **Unique index** `unique_record_listens` on `(room_playlist_record_id, song_id, user_id)` — at most one listen per user per playback (see `db/structure.sql`). Also separately indexed on `room_playlist_record_id` and `song_id`.
+
+### `Song` — `app/models/song.rb`
+- Validates `youtube_id` presence (songs are YouTube videos).
+- `youtube_tags` is a `varchar[]` array column on `songs`.
+- **Full-text + fuzzy search.** `songs.text_search` is a generated `tsvector` column (`GENERATED ALWAYS AS … STORED`) that weights `name` and `channel_title` as A, `youtube_tags` (via `immutable_array_to_string`) as B, and `description` as C. There's a custom IMMUTABLE function `public.immutable_array_to_string` defined in `db/structure.sql` to make this work in a generated column.
+- Three search scopes:
+  - `Song.fulltext_search(q)` — pure `tsvector @@ plainto_tsquery` ranked by `ts_rank`.
+  - `Song.fuzzy_search(q)` — pg_trgm `<%` operator over `name + channel_title + youtube_tags`, ordered by `<<->` word-distance.
+  - `Song.search(q)` — 3-tier combined query: FTS, then trigram fuzzy, then `ILIKE` substring, with a `CASE` ordering that puts FTS matches first.
+- Indexes that imply hot search paths: `index_songs_on_text_search` (GIN on the tsvector), `index_songs_on_searchable_content_trgm` (GiST trigram on the combined expression), `index_songs_on_name` (GIN trgm), plus btree indexes on `channel_id`, `duration_in_seconds`, `published_at`, `youtube_id`, and a separate `song_name_order_index` on `name` for ordering.
+- `has_many :users, through: :library_records` — note this is **unscoped** (it ignores the `pending_recommendation` filter that `User#library_records` applies).
+
+### `LibraryRecord` — `app/models/library_record.rb`
+- The user's saved library: one `Song` saved by one `User`, optionally `from_user` (the recommender).
+- `enum :source, { saved_from_history: "saved_from_history", pending_recommendation: "pending_recommendation", accepted_recommendation: "accepted_recommendation" }` — string-backed. Drives the recommendation flow: a `from_user` sends a song to another user; it starts as `pending_recommendation` (hidden from `User#library_records`) until the recipient accepts it (`accepted_recommendation`). Songs the user saves themselves are `saved_from_history`.
+- Indexed on `created_at`, `song_id`, `user_id`, and `source` (`db/structure.sql`).
+- `has_many :tags, through: :tag_library_records`.
+
+### `Tag` — `app/models/tag.rb`
+- Per-user tag (belongs_to `User` — tags are private to each user, not global). Validates `name` presence. Indexed on `user_id`.
+
+### `TagLibraryRecord` — `app/models/tag_library_record.rb`
+- Join between `Tag` and `LibraryRecord`. Explicit `self.table_name = "tags_library_records"` (Rails would otherwise look for `tag_library_records`).
+- **Unique composite index** on `(tag_id, library_record_id)` prevents duplicate tagging. Also individually indexed on each FK.
+
+### `Message` — `app/models/message.rb`
+- Chat-style messages tied to a `Room` (required) and `User` (required), optionally to a `RoomPlaylistRecord` and/or `Song`. Has a `pinned` boolean (default `false`).
+- Indexed on `created_at` and `room_id` (hot path: paginated room chat history).
+
+### `Invitation` — `app/models/invitation.rb`
+- Belongs to `Team` and `inviting_user` (`User` via `invited_by_id`).
+- Surprising: `invited_user` is a `belongs_to` against `User` keyed by **email** (`foreign_key: :email, primary_key: :email`) — so the association resolves the invited user lazily once they exist (or stays `nil` until signup).
+- `Invitation.token` class method generates a `SecureRandom.uuid` (note: the `token` column is `uuid` type). The model does **not** auto-assign — callers must set the token explicitly.
+- `enum :invitation_state, { pending: "pending", accepted: "accepted" }` — string-backed.
+- Indexed on `token` (lookup-by-link path).
+
+## Notes and gotchas
+
+- **No `app/models/concerns/`** — directory does not exist; no shared model concerns.
+- **All tables use `uuid` PKs.** Foreign keys are `uuid` columns; no integer IDs anywhere.
+- **Devise + Doorkeeper.** Devise owns user auth columns on `users`; Doorkeeper owns `oauth_access_grants`, `oauth_access_tokens`, `oauth_applications` (no Rails models in `app/models/` for these — they come from the gems). Token uniqueness enforced at DB level (`db/structure.sql`).
+- **Two join tables use legacy plural-plural naming** (`teams_users`, `tags_library_records`) and the corresponding Rails models override `self.table_name` accordingly.
+- **`Room#user_rotation`** as a Postgres `uuid[]` is unusual — anyone modifying queue/rotation logic should expect array semantics, not a join table.
+- **`pending_recommendation` is invisible by default.** The default-scope-like behavior on `User#library_records` means almost any `current_user.library_records` or `current_user.songs` call silently filters them out. Use `LibraryRecord` directly when querying recommendations.
+- **Generated tsvector column.** `songs.text_search` is maintained by Postgres — you cannot write to it. Updates to `name`/`channel_title`/`youtube_tags`/`description` automatically refresh it. The custom `immutable_array_to_string` function in `db/structure.sql` is required for the generated expression to be IMMUTABLE.

--- a/autopilot-support/index/structures/infrastructure.md
+++ b/autopilot-support/index/structures/infrastructure.md
@@ -1,0 +1,71 @@
+# Infrastructure
+
+Runtime and operational infrastructure for musicbox-api. This file points at the configuration files and surfaces non-obvious behavior. For day-to-day operational details (deploys, ECS, RDS tunneling) see `README.md`. For ongoing cost tracking see `COSTS.md`.
+
+## Sidekiq
+
+- `config/sidekiq.yml` — concurrency is five and the `timeout` value (eight seconds) is unusually aggressive (Sidekiq's default is twenty-five seconds). Every queue is weighted one, so they round-robin rather than prioritize. The queue names map one-for-one to the workers in `app/workers/` — when a worker is added, both the worker class's queue option and this YAML must be updated or the job won't be picked up.
+- `app/workers/` — one worker per Sidekiq queue. `queue_management_worker.rb` advances room queues; the `broadcast_*_worker.rb` family fans channel updates out via ActionCable; `email_invitation_worker.rb` and `email_password_reset_worker.rb` send Devise-driven mail.
+- `config/initializers/sidekiq.rb` — both server and client are configured against `ENV["SIDEKIQ_REDIS_URL"]`, **not** `REDIS_URL`. The Sidekiq Redis can be a different instance/db than the ActionCable Redis (docker-compose happens to point both at the same host). Log level is read from `ENV["LOG_LEVEL"]` independent of Rails' logger.
+- `config/routes.rb` — the Sidekiq dashboard is mounted at `/workers` (not `/sidekiq`). It is **not behind any authentication constraint** — anyone who can reach the host can see and replay jobs. See `README.md` for the local URL.
+
+## ActionCable
+
+- `config/cable.yml` — uses the `redis` adapter in every non-test environment (test uses the in-memory `test` adapter). `channel_prefix` differs per environment so a single Redis can host multiple deploys safely. `REDIS_URL` is the variable (separate from `SIDEKIQ_REDIS_URL`).
+- `config/routes.rb` mounts the server at `/cable`.
+- `app/channels/application_cable/connection.rb` — auth happens via `?token=` query param resolved through `Doorkeeper::AccessToken.by_token`, not Devise sessions or the `Authorization` header. WebSocket clients cannot use headers, so the bearer token rides in the URL.
+- `app/channels/application_cable/channel.rb` — every channel inherits a `subscribed` hook that rejects unless `current_user.active_room` is set and then `stream_for` that room. Per-channel subclasses (e.g., `app/channels/now_playing_channel.rb`, `room_playlist_channel.rb`, `message_channel.rb`, `pinned_messages_channel.rb`, `record_listens_channel.rb`, `team_channel.rb`, `users_channel.rb`) inherit this behavior — they do not redeclare `subscribed`.
+- `config/application.rb` — `config.action_cable.allowed_request_origins` is built from `ENV["ALLOWED_HOSTS"]` (ampersand-delimited regexes). An unset `ALLOWED_HOSTS` means no origins are allowed.
+- `nginx.conf.erb` — `/cable` is given its own `passenger_app_group_name` and `passenger_force_max_concurrent_requests_per_process 0;` so long-lived WebSocket connections don't block normal Passenger workers.
+
+## Redis
+
+Used by both Sidekiq (`SIDEKIQ_REDIS_URL`) and ActionCable (`REDIS_URL`). These are separate env vars deliberately — production may point them at different instances even though `docker-compose.yml` uses one. There is **no `Rails.cache` Redis** configured; cache store defaults to in-memory.
+
+## PostgreSQL
+
+- `config/database.yml` — single `default` block keyed off `ENV["DATABASE_URL"]`. Pool size follows `RAILS_MAX_THREADS` (default `5`). The `production` block points at the `musicbox-api_staging` database — the URL env var overrides this in practice, but the literal default is suspicious.
+- `db/structure.sql` — the schema dump is SQL rather than `schema.rb` because `config.active_record.schema_format = :sql` in `config/application.rb`; this preserves PostgreSQL-specific functions, triggers, and extensions that `schema.rb` would silently drop.
+- Required extensions, enabled in migrations and present in `db/structure.sql`:
+  - `pgcrypto` (`db/migrate/20171228003631_enable_pgcrypto_extension.rb`) — powers `gen_random_uuid()` default for every primary key (UUIDs are the project-wide default; see `config/application.rb` generator config).
+  - `pg_trgm` (`db/migrate/20200226234544_enable_pgtrgm_extension.rb`) — backs the trigram-based search feature.
+
+## Devise + Doorkeeper
+
+- `config/initializers/devise.rb` — almost entirely defaults; the only meaningful changes are `password_length` (`6..128`) and `reset_password_within` (`6.hours`). No mailer host is set here.
+- `config/initializers/doorkeeper.rb` — `grant_flows %w[password]` only (no authorization code, no client credentials), and `access_token_expires_in nil` (**tokens never expire**). `resource_owner_authenticator` raises by design — the API only uses `resource_owner_from_credentials` (password grant) to mint tokens against Devise's `valid_password?`.
+- `config/routes.rb` — Doorkeeper is mounted via `use_doorkeeper` inside `scope path: "/api"` → `scope path: "/v1"`, so OAuth endpoints live under `/api/v1/oauth/*`. Devise routes are **not** declared — the app does not expose Devise's controllers; authentication is exclusively through Doorkeeper's password grant.
+- `config/initializers/graphiql.rb` — local GraphiQL injects an `Authorization: Bearer <token>` header by minting a Doorkeeper token for the seed user `a@a.a` on each request. If that user doesn't exist, the GraphiQL page fails — see `README.md`.
+
+## Airbrake
+
+- `config/initializers/airbrake.rb` — exception tracking; uses `AIRBRAKE_ID` / `AIRBRAKE_SECRET` env vars. `ignore_environments` is `%w[test]` — staging and development both report. `blocklist_keys` filters `/password/i` and `/authorization/i` from payloads. Errors are sent through `Airbrake::Rails.logger` rather than STDOUT.
+
+## YouTube client
+
+- `app/lib/youtube_client.rb` — the only external HTTP integration. Hits two YouTube Data API v3 endpoints: `videos` (for `find(youtube_id)`, returns snippet + contentDetails including ISO-8601 `duration` parsed via `ActiveSupport::Duration.parse`) and `search`. Reads the API key from `ENV["YOUTUBE_KEY"]`. Uses raw `Net::HTTP` (not Faraday or HTTParty) and **has no rate-limit handling, no retries, and no quota tracking** — non-`Net::HTTPSuccess` responses silently return `nil` / `[]`. The `user` argument is stored but never consulted.
+
+## Docker
+
+- `Dockerfile` — Ruby `3.4.4`, bundler `2.6.7`. `BUNDLE_WITHOUT=production:staging` is set at build time, so the image bakes in dev/test gems and excludes production/staging-only ones — surprising for an image used in non-dev environments. `passenger-config install-standalone-runtime --auto` and `build-native-support` are pre-run so the container boots fast. The final `CMD` is informational only (`echo "Commands: ..."`); real start commands are supplied by `docker-compose.yml` or `ProductionProcfile`.
+- `docker-compose.yml` — four services: `db` (Postgres v15), `redis` (Redis v5 — notably older than the Postgres image), `app` (Passenger fronted by the bundled nginx template), `app-poll-room-queue` (runs `rake room:poll_queue` as a long-running process — the local equivalent of `config/clock.rb`'s `room-poll` job), and `app-sidekiq-workers` (runs `bundle exec sidekiq` with a low db pool and matching Sidekiq concurrency). All app containers share the build via YAML anchors. `bin/wait-for-it.sh` gates startup on db/redis readiness.
+
+## Render
+
+- `render.yaml` — defines a **single web service** that runs `bin/foreman start -f ./ProductionProcfile`. This means foreman fans the Procfile's web/worker/clockwork processes out inside a single Render web dyno, which is unusual (typically each Procfile process would be its own Render service). There is **no separate worker service declared**. Build is delegated to `bin/render-build.sh`. Real production may live elsewhere — `README.md` describes an ECS/Fargate deploy path via `bin/build-push.sh`, which predates this file.
+
+## Procfile
+
+- `ProductionProcfile` (note the name — there is no plain `Procfile`) — three processes started by foreman: `web` (`bin/puma -C config/puma.rb`), `worker` (`bin/sidekiq`), `clockwork` (`bin/clockwork config/clock.rb`). Despite `passenger` being in the Gemfile and `nginx.conf.erb` being shipped, the Render path uses Puma — Passenger is used for the Docker image's local serving and for the legacy ECS deploy.
+
+## nginx
+
+- `nginx.conf.erb` — a Passenger Standalone Nginx config template (not a freestanding nginx config). Notable: `client_max_body_size 1024m;` (1 GB requests allowed), `access_log off;` (no request logs from nginx — Rails STDOUT only), gzip on, `underscores_in_headers on;`, and the `/cable` location override described above. The `passenger_app_group_name` is hardcoded as `musicbox_staging_action_cable` — same group name in production, which means production and staging both name the cable app group "staging" if they share the file.
+
+## Passenger app server
+
+- `gem "passenger"` in `Gemfile` (`6.0.27`). Passenger powers the Docker image (`docker-compose.yml` runs `passenger start -p 3000 --nginx-config-template nginx.conf.erb`). It is **not** used on the Render deploy — that uses Puma via `ProductionProcfile`. `config/puma.rb` configures Puma threads from `RAILS_MAX_THREADS` (default `3`) and listens on `PORT`; the `solid_queue` plugin is wired but only enabled when `SOLID_QUEUE_IN_PUMA` is set (it currently is not — Sidekiq remains the job backend).
+
+## Clockwork (scheduled jobs)
+
+- `config/clock.rb` — a single job: `every(1.second, "room-poll") { RoomQueuePoller.new.poll! }`. Runs the room queue poller once per second. This is the cron-equivalent backbone for advancing playback across all active rooms. Started by the `clockwork` line in `ProductionProcfile`; locally, the equivalent is the `app-poll-room-queue` service in `docker-compose.yml`, which runs `rake room:poll_queue` instead of clockwork (the rake task and the clockwork job both poll the same `RoomQueuePoller`).

--- a/autopilot-support/index/structures/modules.md
+++ b/autopilot-support/index/structures/modules.md
@@ -1,0 +1,34 @@
+# Modules
+
+How non-MVC code is organized: `app/lib/` for plain Ruby service objects and selectors, `app/workers/` for Sidekiq jobs, and `lib/tasks/` for rake.
+
+## `app/lib` organization
+
+Service objects live as top-level classes (not namespaced) directly under `app/lib/`. Two flavors:
+
+- **Domain logic services**: `app/lib/room_playlist_generator.rb` (`RoomPlaylistGenerator`) — interleaves user playlists by rotating through `room.user_rotation`. Called by `app/workers/queue_management_worker.rb` and `app/lib/selectors/room_playlist_records.rb`. `app/lib/room_queue_poller.rb` (`RoomQueuePoller`) — polls for rooms that need their queue advanced (newly enqueued or playback expired) and dispatches `QueueManagementWorker`. Run continuously by the `room:poll_queue` rake task.
+- **External clients**: `app/lib/youtube_client.rb` (`YoutubeClient`) wraps the YouTube Data v3 API via raw `Net::HTTP` (no gem); read `ENV["YOUTUBE_KEY"]`. Only caller is `app/graphql/mutations/song_create.rb` and `app/lib/selectors/search_results.rb`.
+- **Reporting one-offs**: `app/lib/musicbox_unwound.rb` (`MusicboxUnwound`) is a console-only report that `puts` Terminal::Table output and hardcodes the team name `"Plug Dot DJ Expats"` — not wired into GraphQL. `app/lib/unwound.rb` (`Unwound`) is the GraphQL-facing version returning structured hashes; invoked from `QueryType#unwound` in `app/graphql/types/query_type.rb`. Despite the similar names these are separate codepaths.
+- **Errors**: `app/lib/not_authenticated_error.rb` defines `NotAuthenticatedError`, raised by `app/graphql/mutations/base_mutation.rb` and `QueryType` and rescued in `app/controllers/graphql_controller.rb` to convert auth failures into a 401-style GraphQL response.
+
+## Selectors pattern
+
+`app/lib/selectors.rb` only declares the empty `Selectors` module — it is just a namespace anchor. The real work lives in `app/lib/selectors/*.rb`, each a class that wraps a GraphQL `lookahead:` and builds an ActiveRecord relation with the right `includes` to avoid N+1. Pattern: instantiate with `lookahead:` (and other context like `user:`), chain scoping methods that return `self` (e.g., `for_user`, `with_query`, `with_tags`, `in_date_range`), then call a terminal method that returns the relation.
+
+Invoked exclusively from `app/graphql/types/query_type.rb`: `Selectors::LibraryRecords` (library query), `Selectors::Messages` (messages and pinnedMessages — same selector class, two callers), `Selectors::RoomPlaylistRecords` (roomPlaylist field; delegates to `RoomPlaylistGenerator` for the non-historical case), and `Selectors::SearchResults` (falls back from local `Song` search to `YoutubeClient` when local has no hits). `LibraryRecords` is the most complex — it carries custom postgres FTS + trigram fuzzy ranking SQL in `apply_song_search_order`.
+
+## Concerns
+
+There are no concerns. `app/models/concerns/.keep` and `app/controllers/concerns/.keep` are placeholders left by Rails generators; `app/concerns/` does not exist. All model/controller logic lives in the class file directly.
+
+## Workers
+
+All workers are Sidekiq jobs in `app/workers/` and each declares its own named queue via `sidekiq_options queue:`. Three groupings:
+
+- **`broadcast_*` family**: each maps to one ActionCable channel and re-executes a hardcoded GraphQL query through `MusicboxApiSchema.execute` with `context: { override_current_user: true }` (skips auth). Pairings — `broadcast_message_worker.rb` -> `MessageChannel`, `broadcast_now_playing_worker.rb` -> `NowPlayingChannel`, `broadcast_pinned_messages_worker.rb` -> `PinnedMessagesChannel`, `broadcast_playlist_worker.rb` -> `RoomPlaylistChannel`, `broadcast_record_listens_worker.rb` -> `RecordListensChannel`, `broadcast_team_worker.rb` -> `TeamChannel`, `broadcast_users_worker.rb` -> `UsersChannel`. The GraphQL query strings are inlined in each worker's private `query` method.
+- **`email_*` family**: bypasses ActionMailer entirely; both `email_invitation_worker.rb` and `email_password_reset_worker.rb` POST directly to the Mailgun HTTP API at `api.mailgun.net/v3/mg.musicbox.fm/messages` using `Net::HTTP` and an `ENV["MAILGUN_KEY"]` basic-auth credential. Templates (`invitation`, `password-reset`) are stored in Mailgun, not the repo. Each defines its own `DeliveryError`.
+- **Standalone**: `queue_management_worker.rb` (`QueueManagementWorker`) is the central playback advancer — runs `room.with_lock`, calls `RoomPlaylistGenerator` to pick the next record, updates room state, then fans out to `BroadcastTeamWorker`, `BroadcastNowPlayingWorker`, and `BroadcastPlaylistWorker`. Enqueued by `RoomQueuePoller#enqueue_for`.
+
+## `lib/tasks`
+
+Only one rake task exists: `lib/tasks/room.rake` defines `room:poll_queue`, an infinite loop that runs `RoomQueuePoller#poll!` every 0.1s. This is the entry point for the background poller process (intended to run as a long-lived process, not a cron). The `lib/tasks/.keep` file is a leftover Rails generator placeholder.

--- a/autopilot-support/index/structures/resources.md
+++ b/autopilot-support/index/structures/resources.md
@@ -1,0 +1,132 @@
+# Resources
+
+The API surface: a single GraphQL endpoint, a handful of ActionCable channels, and OAuth token issuance via Doorkeeper. There is no traditional REST controller layer — every read and every write flows through `POST /api/v1/graphql`.
+
+## GraphQL endpoint
+
+- `app/controllers/graphql_controller.rb` — the only application controller besides `ApplicationController`. Constructs `context = { current_user: current_user }` and calls `MusicboxApiSchema.execute`. Notable behaviors:
+  - `NotAuthenticatedError` is caught and rendered as bare `head 401` (no JSON body).
+  - In development only, `StandardError` is caught and rendered with full backtrace; in other envs it re-raises.
+  - `ensure_hash` accepts `params[:variables]` as a JSON string, a Hash, `ActionController::Parameters`, or nil — pre-`6.1` shim that still lives here.
+- `app/controllers/application_controller.rb` — inherits from `ActionController::API`. `current_user` is memoized from `doorkeeper_token.resource_owner_id`; no Devise session involvement at the controller layer.
+- `app/graphql/musicbox_api_schema.rb` — schema entry, wires `Types::MutationType` and `Types::QueryType`. No subscription type — real-time delivery is ActionCable, not GraphQL subscriptions.
+- `app/graphql/mutations.rb` and `app/graphql/types.rb` — empty module shells; the actual content lives in the per-class files.
+
+## Mutations
+
+All mutation classes inherit from `Mutations::BaseMutation` (`app/graphql/mutations/base_mutation.rb`), which:
+- Overrides `ready?` to raise `NotAuthenticatedError` when `context[:current_user]` is blank — every mutation is logged-in-only by default.
+- Mutations that must be callable while unauthenticated (account creation, password reset) override `ready?` to return `true` — see `invitation_accept.rb`, `password_reset_complete.rb`, `password_reset_initiate.rb`, `team_create.rb`.
+- Provides `access_token_for(user_id)` which mints a non-expiring Doorkeeper access token with empty scopes. Used by mutations that complete an auth-establishing flow.
+- Field registration happens in `app/graphql/types/mutation_type.rb` — the public mutation field name (snake_case) maps to the mutation class there. The class file basename matches the field name.
+
+### Auth / account creation
+- `team_create.rb` — bundled user-and-team bootstrap. Creates the team owner (or authenticates an existing user with the supplied password), creates the team, returns an access token. Public.
+- `user_update.rb` — updates `User#name`. Uses a `UserUpdateInputObject` nested input class. Silently no-ops on blank attrs (returns an error).
+- `user_password_update.rb` — verifies current password via `valid_password?` before delegating to Devise's `reset_password`.
+
+### Invitations
+- `invitation_create.rb` — `find_or_initialize_by` semantics for `(email, team)` so re-inviting is idempotent. Re-uses an existing token if already pending. Enqueues `EmailInvitationWorker`.
+- `invitation_accept.rb` — public. Creates the user if not present, otherwise re-authenticates against the supplied password. Joins them to the inviting team and flips `invitation_state` to `:accepted`. Returns an access token.
+
+### Password reset
+- `password_reset_initiate.rb` — public. Silently returns `{ errors: [] }` when the email doesn't exist (no enumeration leak). Enqueues `EmailPasswordResetWorker` with the reset token.
+- `password_reset_complete.rb` — public. Checks `reset_password_period_valid?` separately from token validity to give a distinct expired-token error. Returns an access token on success.
+
+### Teams
+- `team_activate.rb` — sets `current_user.active_team_id`. Broadcasts both old and new teams via `BroadcastTeamWorker` so presence updates on both sides.
+- `team_create.rb` — see Auth above. The same mutation creates the user and the team in one step.
+
+### Rooms
+- `room_activate.rb` — sets `current_user.active_room_id` AND `active_team_id` from the room. Triggers `BroadcastTeamWorker`.
+- `room_create.rb` — scoped to `current_user.active_team`. No team_id argument; the room inherits the user's active team.
+
+### Playlist / queue
+All four playlist mutations operate on the current user's `active_room`. They share a `BroadcastPlaylistWorker.perform_async(room_id)` fan-out.
+- `room_playlist_records_add.rb` — adds songs to the end of the user's slot in the room. Lazily appends `current_user.id` to `room.user_rotation`. Also flips `room.waiting_songs = true`. Creates a `LibraryRecord` for each song if one doesn't already exist (so adding to queue implicitly saves to library).
+- `room_playlist_records_reorder.rb` — full replace-set semantics for the user's waiting records: anything not in `ordered_records` gets destroyed. Uses a nested `OrderedPlaylistRecordInputObject`. Can also create new records when `room_playlist_record_id` is null.
+- `room_playlist_record_delete.rb` — single-record delete; verifies ownership.
+- `room_playlist_record_abandon.rb` — skip-current-song. Sets `room.playing_until = 1.second.ago` rather than mutating the record itself; the queue poller picks up the expired playback. Refuses unless the current record belongs to `current_user`.
+
+### Messages
+- `message_create.rb` — implicitly associates the message with `current_user.active_room.current_record` and that record's `song_id` (so chat is pinned-by-default to whatever is playing). Enqueues `BroadcastMessageWorker(room_id, message_id)`.
+- `message_pin.rb` — toggles `Message#pinned`. Only the message author can pin. Enqueues `BroadcastPinnedMessagesWorker(room_id, song_id)`.
+
+### Library
+- `library_record_delete.rb` — soft scope: only deletes when the record belongs to `current_user`.
+
+### Songs
+- `song_create.rb` — `find_or_initialize_by(youtube_id:)`. For newly-created songs, calls `YoutubeClient.new(current_user).find(youtube_id)` and fills metadata (description, duration, name, thumbnail, channel, published_at, etc.). Also creates a `LibraryRecord` linking the song to `current_user` — when `from_user_id` is supplied, the record's `source` is set to `"saved_from_history"`.
+
+### Tagging
+- `tag_create.rb` — scoped to `current_user`; tag uniqueness is per-user.
+- `tag_toggle.rb` — applies a single `tag_id` to a set of `add_ids` and removes from a set of `remove_ids` in one call. Uses `TagLibraryRecord.insert_all` and `delete_all` for bulk efficiency — no callbacks fire.
+
+### Recommendations
+- `recommendation_create.rb` — creates a `LibraryRecord` with `source: "pending_recommendation"` on the recipient, with `from_user_id = current_user.id`. Refuses if the recipient already has a LibraryRecord for the song.
+- `recommendation_accept.rb` — flips `LibraryRecord#source` from `"pending_recommendation"` to `"accepted_recommendation"`. The recommendation model is reused as the library record once accepted.
+
+### Listening
+- `record_listen_create.rb` — only allowed when the supplied `record_id` matches `current_user.active_room.current_record_id`. Approval is clamped to `0..3`. Uses `find_or_create_by!` with a `RecordNotUnique` rescue to handle races. Broadcasts via `BroadcastRecordListensWorker(record_id)`.
+
+## Query type
+
+`app/graphql/types/query_type.rb` — one big class with all top-level queries. Notable patterns:
+
+- Most resolvers call a local `confirm_current_user!` that raises `NotAuthenticatedError` unless `context[:current_user]` is present OR `context[:override_current_user]` is set. The override lets background workers (e.g. broadcast workers) execute queries on behalf of a user. The `invitation` and `unwound` queries deliberately skip this guard so they can be called by recipients of email links and (in unwound's case) by anonymous clients.
+- `extras: [:lookahead]` is used heavily — resolvers manually compute `includes` from the lookahead selection set to avoid N+1. See `recommendations`, `record_listens`.
+- Resolvers delegate to `Selectors::*` classes in `app/lib/selectors/` for non-trivial scoping (`Selectors::LibraryRecords`, `Selectors::Messages`, `Selectors::RoomPlaylistRecords`, `Selectors::SearchResults`). The selector receives the lookahead, scopes by `current_user`, then exposes chainable methods that mirror the GraphQL arguments.
+- `pinned_messages` carries a comment about its dual-mode resolution (current_user vs. an explicit `room_id` from a broadcast worker context) — read it before changing.
+- `room_playlist_for_user` is a current-user shortcut that bypasses `Selectors::RoomPlaylistRecords` and queries `RoomPlaylistRecord` directly with `.played` / `.waiting` scopes.
+- `unwound` builds a `Unwound` value object (`app/lib/unwound.rb`) rather than scoping ActiveRecord — it's a stats aggregator.
+
+## Base types and helpers
+
+Located in `app/graphql/types/`. The `base_*` files are intentionally thin — they exist purely so domain types can inherit from project-local classes rather than from `GraphQL::Schema::*` directly:
+
+- `base_object.rb`, `base_enum.rb`, `base_input_object.rb`, `base_interface.rb`, `base_scalar.rb`, `base_union.rb` — empty subclasses; extend these when adding cross-cutting behavior.
+- `date_time_type.rb` — custom scalar. `coerce_input` parses with `Time.zone.parse`; `coerce_result` emits `utc.iso8601`. All datetime arguments use this rather than the built-in `GraphQL::Types::ISO8601DateTime`.
+- `email_type.rb` — scalar that downcases on input. Use this for any email argument; it normalizes before the resolver runs so `find_by(email:)` works.
+- `order_type.rb` — input object pairing `ordered_field` and `ordered_direction`. Used by `library_records` query.
+- `ordered_field_type.rb` — scalar that `underscore`s on input and `camelize(:lower)`s on output, bridging GraphQL camelCase and Rails snake_case column names.
+- `ordered_direction_type.rb` — scalar that downcases.
+- `search_result_type.rb` — union of `Types::SongType` and `Types::YoutubeResultType`. The resolver inspects whether the value is a `Song` or an `OpenStruct` (YouTube results are wrapped in OpenStructs).
+
+Domain types live as `*_type.rb` siblings (`song_type.rb`, `room_type.rb`, `user_type.rb`, etc.) — each one wraps a corresponding ActiveRecord model. See `app/graphql/types/`.
+
+## ActionCable channels
+
+Mounted at `/cable` (see `config/routes.rb`). All channels inherit from `ApplicationCable::Channel`.
+
+- `app/channels/application_cable/connection.rb` — connection-level auth. `current_user` is resolved from `request.query_parameters[:token]` via `Doorkeeper::AccessToken.by_token` — the OAuth token is passed as a `?token=…` query string on the WebSocket URL. Unauthenticated connections are rejected. The connection is `identified_by :current_user`.
+- `app/channels/application_cable/channel.rb` — base channel implementing `subscribed` as `stream_for current_user.active_room` (rejecting if no active room). This means `MessageChannel`, `NowPlayingChannel`, `PinnedMessagesChannel`, `RecordListensChannel`, `RoomPlaylistChannel` are all room-scoped by inheritance — they have no body of their own and exist purely for the broadcast namespace.
+
+Per-channel notes:
+- `message_channel.rb` — receives broadcasts from `BroadcastMessageWorker` (one per `MessageCreate`).
+- `pinned_messages_channel.rb` — receives broadcasts from `BroadcastPinnedMessagesWorker` (one per `MessagePin`).
+- `now_playing_channel.rb` — receives queue/playback advancement broadcasts (e.g. from `RoomQueuePoller`/`BroadcastPlaylistWorker`).
+- `room_playlist_channel.rb` — receives broadcasts from `BroadcastPlaylistWorker` (playlist add/reorder/delete).
+- `record_listens_channel.rb` — receives broadcasts from `BroadcastRecordListensWorker` (one per `RecordListenCreate`).
+- `team_channel.rb` — overrides `subscribed` to stream for `current_user.active_team` instead of active_room. Receives broadcasts from `BroadcastTeamWorker` (team/room activation, presence). The only channel that is team-scoped instead of room-scoped.
+- `users_channel.rb` — overrides `unsubscribed` to clear `current_user.active_room_id` when the WS disconnects, then enqueues `BroadcastTeamWorker(active_team_id)` so other clients see the user leave. This is the only "presence" mechanism — there is no separate Redis presence store.
+
+## Routes
+
+`config/routes.rb` is short. The whole file:
+
+- `Sidekiq::Web` is mounted at `/workers`. There is no authentication wrapper — be aware before exposing the app to the open internet.
+- `ActionCable.server` mounted at `/cable` — see channel auth above.
+- `GraphiQL::Rails::Engine` mounted at `/graphiql`, pointing at `graphql_path: "/api/v1/graphql"`. `config/initializers/graphiql.rb` injects a `Bearer` header derived from a hard-coded local Doorkeeper token (see that initializer) so GraphiQL works against the auth-guarded schema.
+- `POST /api/v1/graphql` → `graphql#execute`.
+- `use_doorkeeper` (Doorkeeper's `/oauth/token`, `/oauth/applications`, etc.) mounted under `/api/v1/`. The clients exchange Devise email/password for an access token via the standard password grant here.
+- **Devise is configured (`config/initializers/devise.rb`) but NOT routed.** There is no `devise_for :users`. Devise's role is purely model-level (`User` includes `:database_authenticatable`, etc.) and is exercised through the GraphQL mutations (`TeamCreate`, `InvitationAccept`, `PasswordReset*`) and through Doorkeeper's password grant. Adding a Devise route would conflict with that flow.
+
+## Authorization model
+
+Three layers, each independent:
+
+1. **GraphQL resolver layer.** `context[:current_user]` is set in `GraphqlController#execute` from `current_user` (which reads `doorkeeper_token.resource_owner_id`). Mutations check via `Mutations::BaseMutation#ready?`; queries check via `confirm_current_user!`. Public mutations override `ready?`. Both layers raise `NotAuthenticatedError` (`app/lib/not_authenticated_error.rb`), which the controller catches and converts to HTTP 401. There is no `Pundit`/`CanCan` style policy layer — finer-grained authorization (e.g. "only the message author can pin") is enforced inline in resolvers via `find_by(user: current_user, …)`.
+2. **OAuth layer (Doorkeeper).** `app/controllers/application_controller.rb#current_user` reads `doorkeeper_token` and resolves the resource owner. All tokens minted from in-app flows (`access_token_for` in `BaseMutation`) are non-expiring with empty scopes; tokens minted via the standard password grant come through `use_doorkeeper`'s `/oauth/token` route.
+3. **ActionCable layer.** `ApplicationCable::Connection` does its own token verification from the WebSocket query string — it does not share `current_user` with the HTTP controller. Channels add a second authorization check in `subscribed` (reject if `active_room` / `active_team` is blank).
+
+There is no admin role, no scope system, and no rate-limiting middleware in the codebase. Tokens are bearer credentials with full access to the resource owner's data.

--- a/autopilot-support/index/structures/testing.md
+++ b/autopilot-support/index/structures/testing.md
@@ -1,0 +1,81 @@
+# Testing
+
+RSpec-based test suite under `spec/`, mirroring the GraphQL-first architecture rather than the Rails MVC layout. Most tests are request specs that POST to the single `/api/v1/graphql` endpoint; there are no controller specs, no system/feature specs, and no view specs.
+
+## Helper setup
+
+- `spec/rails_helper.rb` is the heavyweight entry point — sets `RAILS_ENV=test`, requires `rspec/rails` and `sidekiq/testing`, then auto-requires every file under `spec/support/**/*.rb`. Includes `FactoryBot::Syntax::Methods` globally so `create(:foo)` works without prefixing `FactoryBot.`.
+- `spec/spec_helper.rb` is lightweight — only requires `webmock/rspec` (so every spec has outbound HTTP blocked by default) and defines a `:not_change` negated matcher (used in mutation specs to combine multiple `not_change(...)` expectations with `and`).
+- DatabaseCleaner is configured in `rails_helper.rb`: `:transaction` strategy per example via `config.around`, with an initial `:truncation` clean before the suite. `DatabaseCleaner.allow_remote_database_url = true` is set so the suite can run against a non-local Postgres in CI/Docker. Rails' default transactional fixtures are disabled in favor of this.
+- `config.infer_spec_type_from_file_location!` is on — but request specs still explicitly tag `type: :request` because they live in `spec/integration`, `spec/mutations`, and `spec/queries` (none of which Rails auto-infers).
+- Gemfile test group: `factory_bot_rails`, `database_cleaner`, `webmock`, `rspec-sidekiq`, `rspec-rails`.
+
+## Factories
+
+All factories live flat under `spec/factories/` — one file per top-level model, no nested traits or sequences. Conventions worth knowing:
+
+- `spec/factories/users.rb` — note the **plural filename** (the only plural one); generates a unique email via `SecureRandom.uuid` to avoid uniqueness collisions across the suite. Default password is `"hunter2"`.
+- `spec/factories/team.rb` — auto-creates an `owner` user via `create(:user)`. Hardcoded name `"Fine Musical Folks"`.
+- `spec/factories/room.rb` — depends on `team` association; defaults `current_record: nil`, `waiting_songs: false`.
+- `spec/factories/song.rb` — hardcoded `youtube_id: "abcde"`; tests that need uniqueness override it explicitly.
+- `spec/factories/room_playlist_record.rb` — defaults `play_state: "waiting"`, `order: 1`.
+- `spec/factories/library_record.rb`, `message.rb`, `tag.rb` — all minimal, pulling associations from their default factories.
+
+There is no factory for `Invitation`, `RecordListen`, or `Recommendation` — specs build those with `Model.create!` directly. Adding one is a safe extension if you find yourself repeating the same instantiation.
+
+## Support helpers
+
+Three modules, each opt-in via `include` inside `RSpec.describe`:
+
+- `spec/support/auth_helper.rb` (`AuthHelper`) — the canonical way to authenticate a test request. `auth_headers(user)` mints (and memoizes per user) a `Doorkeeper::AccessToken` and returns a `Bearer` header. `graphql_request(query:, variables:, user:)` is the workhorse: it POSTs to `/api/v1/graphql` with the query/variables JSON body and the auth headers. Default `user:` is `create(:user)` — i.e., omitting the user still authenticates as a fresh user, never anonymously. Auth is **not** stubbed or mocked; tests exercise the real Doorkeeper token path end-to-end.
+- `spec/support/graphql_helper.rb` (`GraphQLHelper`) — holds a small set of shared GraphQL query strings reused across specs (currently just `room_activate_mutation` and `room_playlist_query`). Most specs inline their query string in a private `query` method rather than adding it here.
+- `spec/support/json_helper.rb` (`JsonHelper`) — `json_body` parses `response.body` with `symbolize_names: true`. It also asserts `response.successful?` and dumps the body on failure, which surfaces 500s clearly instead of letting them masquerade as nil-key errors deep in a `dig` chain.
+
+## Integration tests
+
+`spec/integration/requests_spec.rb` is the **only** integration spec — a single, long-form scenario test that walks three users through joining a room, building a collaborative playlist, and verifying both the broadcast payloads and the final query order. Notable choices:
+
+- Wraps the whole example in `Sidekiq::Testing.inline!` so worker fan-out executes synchronously.
+- Includes `ActionCable::TestHelper` to use `have_broadcasted_to(...).with do |msg| ... end` for asserting on channel payloads.
+- Exercises the user-rotation playlist algorithm end-to-end (see `features/playlist-management/` for the underlying logic).
+
+Add new high-level cross-feature scenarios here; per-mutation/per-query coverage belongs in `spec/mutations/` or `spec/queries/`.
+
+## Mutation specs
+
+Pattern in `spec/mutations/*_spec.rb`:
+
+- `type: :request`, includes `AuthHelper` and `JsonHelper` (plus `GraphQLHelper` only when reusing shared queries).
+- Each file defines a private `query` method returning a heredoc-style GraphQL string with `$variable` placeholders.
+- Calls `graphql_request(query: query, variables: { ... }, user: current_user)` then inspects `json_body.dig(:data, :mutationName, ...)`.
+- Side-effect assertions use `have_enqueued_sidekiq_job(...)` (from `rspec-sidekiq`) to verify broadcast workers fire — specs do not run the workers themselves. See `message_create_spec.rb` and `room_activate_spec.rb` for the canonical shape.
+- External-service calls are stubbed with `instance_double` / `receive` — e.g. `song_create_spec.rb` stubs `YoutubeClient.new` rather than letting WebMock intercept.
+- Error cases live in `describe "error"` or `describe "failure"` blocks and assert `data[:errors]` is non-empty rather than checking HTTP status (GraphQL returns 200 with errors in body).
+
+## Query specs
+
+`spec/queries/*_spec.rb` follow the same `type: :request` / `AuthHelper` / `JsonHelper` pattern as mutations. They tend to set up rich fixture graphs with `let!` (see `room_playlist_spec.rb` for the multi-record ordering setup) and assert on the shape returned by `json_body.dig(:data, :queryName)`. `search_spec.rb` demonstrates stubbing `YoutubeClient` for the fallback path when local search misses.
+
+## Worker specs
+
+`spec/workers/*_spec.rb` are `type: :worker` and call `described_class.new.perform(...)` directly (no Sidekiq enqueuing in between).
+
+- **Broadcast workers** assert on `have_broadcasted_to(target).from_channel(ChannelClass).with do |msg| ... end`. See `broadcast_message_worker_spec.rb`.
+- **Email workers** use `spec/workers/email_worker_shared_examples.rb` — a `shared_examples "a mailgun worker"` block that stubs the Mailgun HTTP endpoint via WebMock and runs `described_class.new.perform(*arguments)`. Each email worker spec `require_relative`s the shared file and calls `it_behaves_like "a mailgun worker" do let(:arguments) { ... }; let(:payload) { ... }; end`. Adding a new mailgun worker means adding a spec that reuses this block.
+- `queue_management_worker_spec.rb` uses `ActiveSupport::Testing::TimeHelpers#travel_to` for asserting on `playing_until` timestamps, and combines synchronous `worker.perform(...)` with `have_enqueued_sidekiq_job(...)` to verify it dispatches downstream broadcast workers.
+
+`rspec-sidekiq` is the gem providing `have_enqueued_sidekiq_job`. There is no global Sidekiq inline/fake mode set in `rails_helper.rb` — individual specs opt in via `Sidekiq::Testing.inline!` when they want fan-out to execute (currently only `spec/integration/requests_spec.rb` does this).
+
+## Model specs
+
+`spec/models/*_spec.rb` cover **only relationships** — they assert `has_many`, `belongs_to`, and join behavior by creating records and reading back associations. There are **no** validation tests, callback tests, or scope tests in the model specs. Business logic that lives on models is exercised indirectly through the mutation/query specs that call it. If you're adding a method to a model, the convention is to test it through the GraphQL resolver that exposes it, not via a unit spec on the model.
+
+## Lib specs
+
+`spec/lib/` covers plain-Ruby service objects in `app/lib/`:
+
+- `spec/lib/room_playlist_generator_spec.rb` — tests `RoomPlaylistGenerator#playlist` by constructing rooms with specific `user_rotation` arrays and asserting the interleaved record order. Passes the `RoomPlaylistRecord.includes(:song, :user)` relation in explicitly to match the production call site.
+- `spec/lib/room_queue_poller_spec.rb` — tests `RoomQueuePoller#poll!` by creating rooms in each "needs polling?" state and asserting which ones trigger `QueueManagementWorker` enqueues. This is the most direct documentation of the poller's selection logic.
+- `spec/lib/arel/full_text_search_spec.rb` covers the custom Arel/FTS helper used by selectors.
+
+No specs exist for `YoutubeClient`, `MusicboxUnwound`, or `Unwound` — they are exercised only through the GraphQL specs that call them.


### PR DESCRIPTION
Bootstraps `autopilot-support/index/` — a navigable map of the codebase for the autopilot skill (and humans). 57 markdown files: a manifest, 5 cross-cutting structure files (modules, data-model, resources, infrastructure, testing), and 17 feature directories each with the three-file `map / patterns / boundaries` convention.

The index points to files, never duplicates code, and only captures non-obvious info — symbol names rather than line numbers, the *why* and *where to look* rather than the *what*. The manifest at `autopilot-support/index/CLAUDE.md` is the entry point and links every file.

A couple of incidental findings worth knowing about (documented in the relevant feature's `boundaries.md`, not fixed here):

- `Song.search`'s 3-tier ranked search (tsvector + pg_trgm + ILIKE) is implemented on the model but not wired through the GraphQL `search` field — `Selectors::SearchResults#from_all_songs` still uses plain ILIKE on `songs.name`.
- `YoutubeClient` has no error handling, no retries, and is not wired to Airbrake despite the initializer being configured.

## Test plan
- [ ] Skim `autopilot-support/index/CLAUDE.md` and spot-check a few feature directories.
- [ ] Confirm the manifest's one-liners match what each feature's `map.md` says.